### PR TITLE
Reduce the number of object allocations on the decode/encode hotpath

### DIFF
--- a/iabgpp-encoder/pom.xml
+++ b/iabgpp-encoder/pom.xml
@@ -20,6 +20,11 @@
             <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.5.12</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -53,4 +58,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/datatype/encoder/FixedIntegerEncoder.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/datatype/encoder/FixedIntegerEncoder.java
@@ -1,34 +1,34 @@
 package com.iab.gpp.encoder.datatype.encoder;
 
+import static com.iab.gpp.encoder.datatype.encoder.AbstractBase64UrlEncoder.isInvalidBitString;
+
 import java.util.regex.Pattern;
 import com.iab.gpp.encoder.error.DecodingException;
 
 public class FixedIntegerEncoder {
 
-  private static Pattern BITSTRING_VERIFICATION_PATTERN = Pattern.compile("^[0-1]*$", Pattern.CASE_INSENSITIVE);
-
   public static String encode(int value, int bitStringLength) {
     // let bitString = value.toString(2);
 
-    String bitString = "";
+    StringBuilder bitString = new StringBuilder();
     while (value > 0) {
       if ((value & 1) == 1) {
-        bitString = "1" + bitString;
+        bitString.insert(0, "1");
       } else {
-        bitString = "0" + bitString;
+        bitString.insert(0, "0");
       }
       value = value >> 1;
     }
 
     while (bitString.length() < bitStringLength) {
-      bitString = "0" + bitString;
+      bitString.insert(0, "0");
     }
 
-    return bitString;
+    return bitString.toString();
   }
 
   public static int decode(String bitString) throws DecodingException {
-    if (!BITSTRING_VERIFICATION_PATTERN.matcher(bitString).matches()) {
+    if (isInvalidBitString(bitString)) {
       throw new DecodingException("Undecodable FixedInteger '" + bitString + "'");
     }
 


### PR DESCRIPTION
When profiling I noticed a large number of strings being generated from AbstractBase64UrlEncoder.decode(). I think this is mostly attributable to the string concatenation inside the various loops. To fix this I've switched to using a StringBuilder. This avoids new strings being allocated on each iteration.

I've also removed the use of regular expressions to validate inputs these are also relatively expensive to be happening at such a low level of the code. For bitString validation I've used a simple char inspecting method. For base64 I just used the absence of it appearing in the REVERSE_DICT to indicate this is an invalid base64 string.

Finally to reduce auto-boxing I switched to using a Char2IntOpenHashMap for holding the REVERSE_DICT. To do this I've had to import a 3rd party fast utils lib - which is a lightweight collection of optimised primitive collection types, useful in cases like this.