### PR TITLE
Conditionally skip MSPA validation

### DIFF
--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCaV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCaV1CoreSegment.java
@@ -160,7 +160,7 @@ public class UsCaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
     } else if (mspaServiceProviderMode == 1) {
       if (mspaOptOutOptionMode != 2) {
         throw new ValidationException("Invalid usca mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaServiceProviderMode + "}");
+            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
       }
 
       if (saleOptOutNotice != 0) {

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCaV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCaV1CoreSegment.java
@@ -3,6 +3,7 @@ package com.iab.gpp.encoder.segment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+
 import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
 import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
 import com.iab.gpp.encoder.bitstring.BitStringEncoder;
@@ -100,6 +101,8 @@ public class UsCaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
     Integer sharingOptOut = ((EncodableFixedInteger) fields.get(UsCaV1Field.SHARING_OPT_OUT)).getValue();
     Integer saleOptOutNotice = ((EncodableFixedInteger) fields.get(UsCaV1Field.SALE_OPT_OUT_NOTICE)).getValue();
     Integer saleOptOut = ((EncodableFixedInteger) fields.get(UsCaV1Field.SALE_OPT_OUT)).getValue();
+    Integer mspaCoveredTransaction =
+        ((EncodableFixedInteger) fields.get(UsCaV1Field.MSPA_COVERED_TRANSACTION)).getValue();
     Integer mspaServiceProviderMode =
         ((EncodableFixedInteger) fields.get(UsCaV1Field.MSPA_SERVICE_PROVIDER_MODE)).getValue();
     Integer mspaOptOutOptionMode =
@@ -141,47 +144,49 @@ public class UsCaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
       }
     }
 
-    if (mspaServiceProviderMode == 0) {
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usca mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
+    if (mspaCoveredTransaction != 2) {
+      if (mspaServiceProviderMode == 0) {
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usca mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
 
-      if (sharingOptOutNotice != 0) {
-        throw new ValidationException("Invalid usca mspa service provider mode / sharing opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
-      }
+        if (sharingOptOutNotice != 0) {
+          throw new ValidationException("Invalid usca mspa service provider mode / sharing opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
+        }
 
-      if (sensitiveDataLimtUserNotice != 0) {
-        throw new ValidationException(
-            "Invalid usca mspa service provider mode / sensitive data limit use notice combination: {"
-                + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 1) {
-      if (mspaOptOutOptionMode != 2) {
-        throw new ValidationException("Invalid usca mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
-      }
+        if (sensitiveDataLimtUserNotice != 0) {
+          throw new ValidationException(
+              "Invalid usca mspa service provider mode / sensitive data limit use notice combination: {"
+              + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 1) {
+        if (mspaOptOutOptionMode != 2) {
+          throw new ValidationException("Invalid usca mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
 
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usca mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usca mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
 
-      if (sharingOptOutNotice != 0) {
-        throw new ValidationException("Invalid usca mspa service provider mode / sharing opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
-      }
+        if (sharingOptOutNotice != 0) {
+          throw new ValidationException("Invalid usca mspa service provider mode / sharing opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
+        }
 
-      if (sensitiveDataLimtUserNotice != 0) {
-        throw new ValidationException(
-            "Invalid usca mspa service provider mode / sensitive data limit use notice combination: {"
-                + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 2) {
-      if (mspaOptOutOptionMode != 1) {
-        throw new ValidationException("Invalid usca mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        if (sensitiveDataLimtUserNotice != 0) {
+          throw new ValidationException(
+              "Invalid usca mspa service provider mode / sensitive data limit use notice combination: {"
+              + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 2) {
+        if (mspaOptOutOptionMode != 1) {
+          throw new ValidationException("Invalid usca mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
       }
     }
   }

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCoV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCoV1CoreSegment.java
@@ -3,6 +3,7 @@ package com.iab.gpp.encoder.segment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+
 import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
 import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
 import com.iab.gpp.encoder.bitstring.BitStringEncoder;
@@ -100,6 +101,8 @@ public class UsCoV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
         ((EncodableFixedInteger) fields.get(UsCoV1Field.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).getValue();
     Integer targetedAdvertisingOptOut =
         ((EncodableFixedInteger) fields.get(UsCoV1Field.TARGETED_ADVERTISING_OPT_OUT)).getValue();
+    Integer mspaCoveredTransaction =
+        ((EncodableFixedInteger) fields.get(UsCoV1Field.MSPA_COVERED_TRANSACTION)).getValue();
     Integer mspaServiceProviderMode =
         ((EncodableFixedInteger) fields.get(UsCoV1Field.MSPA_SERVICE_PROVIDER_MODE)).getValue();
     Integer mspaOptOutOptionMode =
@@ -139,25 +142,27 @@ public class UsCoV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
       }
     }
 
-    if (mspaServiceProviderMode == 0) {
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usco mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 1) {
-      if (mspaOptOutOptionMode != 2) {
-        throw new ValidationException("Invalid usco mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
-      }
+    if (mspaCoveredTransaction != 2) {
+      if (mspaServiceProviderMode == 0) {
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usco mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 1) {
+        if (mspaOptOutOptionMode != 2) {
+          throw new ValidationException("Invalid usco mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
 
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usco mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 2) {
-      if (mspaOptOutOptionMode != 1) {
-        throw new ValidationException("Invalid usco mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usco mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 2) {
+        if (mspaOptOutOptionMode != 1) {
+          throw new ValidationException("Invalid usco mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
       }
     }
   }

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCoV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCoV1CoreSegment.java
@@ -128,12 +128,12 @@ public class UsCoV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 1) {
-      if (saleOptOut != 1 && saleOptOut != 2) {
+      if (targetedAdvertisingOptOut != 1 && targetedAdvertisingOptOut != 2) {
         throw new ValidationException("Invalid usco targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 2) {
-      if (saleOptOut != 1) {
+      if (targetedAdvertisingOptOut != 1) {
         throw new ValidationException("Invalid usco targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
@@ -147,7 +147,7 @@ public class UsCoV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
     } else if (mspaServiceProviderMode == 1) {
       if (mspaOptOutOptionMode != 2) {
         throw new ValidationException("Invalid usco mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaServiceProviderMode + "}");
+            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
       }
 
       if (saleOptOutNotice != 0) {

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCtV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCtV1CoreSegment.java
@@ -3,6 +3,7 @@ package com.iab.gpp.encoder.segment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+
 import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
 import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
 import com.iab.gpp.encoder.bitstring.BitStringEncoder;
@@ -100,6 +101,8 @@ public class UsCtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
         ((EncodableFixedInteger) fields.get(UsCtV1Field.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).getValue();
     Integer targetedAdvertisingOptOut =
         ((EncodableFixedInteger) fields.get(UsCtV1Field.TARGETED_ADVERTISING_OPT_OUT)).getValue();
+    Integer mspaCoveredTransaction =
+        ((EncodableFixedInteger) fields.get(UsCtV1Field.MSPA_COVERED_TRANSACTION)).getValue();
     Integer mspaServiceProviderMode =
         ((EncodableFixedInteger) fields.get(UsCtV1Field.MSPA_SERVICE_PROVIDER_MODE)).getValue();
     Integer mspaOptOutOptionMode =
@@ -139,25 +142,27 @@ public class UsCtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
       }
     }
 
-    if (mspaServiceProviderMode == 0) {
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usct mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 1) {
-      if (mspaOptOutOptionMode != 2) {
-        throw new ValidationException("Invalid usct mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
-      }
+    if (mspaCoveredTransaction != 2) {
+      if (mspaServiceProviderMode == 0) {
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usct mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 1) {
+        if (mspaOptOutOptionMode != 2) {
+          throw new ValidationException("Invalid usct mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
 
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usct mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 2) {
-      if (mspaOptOutOptionMode != 1) {
-        throw new ValidationException("Invalid usct mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usct mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 2) {
+        if (mspaOptOutOptionMode != 1) {
+          throw new ValidationException("Invalid usct mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
       }
     }
   }

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCtV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCtV1CoreSegment.java
@@ -128,12 +128,12 @@ public class UsCtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 1) {
-      if (saleOptOut != 1 && saleOptOut != 2) {
+      if (targetedAdvertisingOptOut != 1 && targetedAdvertisingOptOut != 2) {
         throw new ValidationException("Invalid usct targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 2) {
-      if (saleOptOut != 1) {
+      if (targetedAdvertisingOptOut != 1) {
         throw new ValidationException("Invalid usct targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
@@ -147,7 +147,7 @@ public class UsCtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
     } else if (mspaServiceProviderMode == 1) {
       if (mspaOptOutOptionMode != 2) {
         throw new ValidationException("Invalid usct mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaServiceProviderMode + "}");
+            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
       }
 
       if (saleOptOutNotice != 0) {

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsNatV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsNatV1CoreSegment.java
@@ -3,6 +3,7 @@ package com.iab.gpp.encoder.segment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+
 import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
 import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
 import com.iab.gpp.encoder.bitstring.BitStringEncoder;
@@ -113,6 +114,8 @@ public class UsNatV1CoreSegment extends AbstractLazilyEncodableSegment<Encodable
         ((EncodableFixedInteger) fields.get(UsNatV1Field.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).getValue();
     Integer targetedAdvertisingOptOut =
         ((EncodableFixedInteger) fields.get(UsNatV1Field.TARGETED_ADVERTISING_OPT_OUT)).getValue();
+    Integer mspaCoveredTransaction =
+        ((EncodableFixedInteger) fields.get(UsNatV1Field.MSPA_COVERED_TRANSACTION)).getValue();
     Integer mspaServiceProviderMode =
         ((EncodableFixedInteger) fields.get(UsNatV1Field.MSPA_SERVICE_PROVIDER_MODE)).getValue();
     Integer mspaOptOutOptionMode =
@@ -188,47 +191,49 @@ public class UsNatV1CoreSegment extends AbstractLazilyEncodableSegment<Encodable
       }
     }
 
-    if (mspaServiceProviderMode == 0) {
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usnat mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
+    if (mspaCoveredTransaction != 2) {
+      if (mspaServiceProviderMode == 0) {
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usnat mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
 
-      if (sharingOptOutNotice != 0) {
-        throw new ValidationException("Invalid usnat mspa service provider mode / sharing opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
-      }
+        if (sharingOptOutNotice != 0) {
+          throw new ValidationException("Invalid usnat mspa service provider mode / sharing opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
+        }
 
-      if (sensitiveDataLimtUserNotice != 0) {
-        throw new ValidationException(
-            "Invalid usnat mspa service provider mode / sensitive data limit use notice combination: {"
-                + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 1) {
-      if (mspaOptOutOptionMode != 2) {
-        throw new ValidationException("Invalid usnat mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
-      }
+        if (sensitiveDataLimtUserNotice != 0) {
+          throw new ValidationException(
+              "Invalid usnat mspa service provider mode / sensitive data limit use notice combination: {"
+              + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 1) {
+        if (mspaOptOutOptionMode != 2) {
+          throw new ValidationException("Invalid usnat mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
 
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usnat mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usnat mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
 
-      if (sharingOptOutNotice != 0) {
-        throw new ValidationException("Invalid usnat mspa service provider mode / sharing opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
-      }
+        if (sharingOptOutNotice != 0) {
+          throw new ValidationException("Invalid usnat mspa service provider mode / sharing opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + sharingOptOutNotice + "}");
+        }
 
-      if (sensitiveDataLimtUserNotice != 0) {
-        throw new ValidationException(
-            "Invalid usnat mspa service provider mode / sensitive data limit use notice combination: {"
-                + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 2) {
-      if (mspaOptOutOptionMode != 1) {
-        throw new ValidationException("Invalid usnat mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        if (sensitiveDataLimtUserNotice != 0) {
+          throw new ValidationException(
+              "Invalid usnat mspa service provider mode / sensitive data limit use notice combination: {"
+              + mspaServiceProviderMode + " / " + sensitiveDataLimtUserNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 2) {
+        if (mspaOptOutOptionMode != 1) {
+          throw new ValidationException("Invalid usnat mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
       }
     }
   }

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsNatV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsNatV1CoreSegment.java
@@ -177,12 +177,12 @@ public class UsNatV1CoreSegment extends AbstractLazilyEncodableSegment<Encodable
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 1) {
-      if (saleOptOut != 1 && saleOptOut != 2) {
+      if (targetedAdvertisingOptOut != 1 && targetedAdvertisingOptOut != 2) {
         throw new ValidationException("Invalid usnat targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 2) {
-      if (saleOptOut != 1) {
+      if (targetedAdvertisingOptOut != 1) {
         throw new ValidationException("Invalid usnat targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
@@ -207,7 +207,7 @@ public class UsNatV1CoreSegment extends AbstractLazilyEncodableSegment<Encodable
     } else if (mspaServiceProviderMode == 1) {
       if (mspaOptOutOptionMode != 2) {
         throw new ValidationException("Invalid usnat mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaServiceProviderMode + "}");
+            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
       }
 
       if (saleOptOutNotice != 0) {

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsUtV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsUtV1CoreSegment.java
@@ -3,6 +3,7 @@ package com.iab.gpp.encoder.segment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+
 import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
 import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
 import com.iab.gpp.encoder.bitstring.BitStringEncoder;
@@ -102,6 +103,8 @@ public class UsUtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
         ((EncodableFixedInteger) fields.get(UsUtV1Field.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).getValue();
     Integer targetedAdvertisingOptOut =
         ((EncodableFixedInteger) fields.get(UsUtV1Field.TARGETED_ADVERTISING_OPT_OUT)).getValue();
+    Integer mspaCoveredTransaction =
+        ((EncodableFixedInteger) fields.get(UsUtV1Field.MSPA_COVERED_TRANSACTION)).getValue();
     Integer mspaServiceProviderMode =
         ((EncodableFixedInteger) fields.get(UsUtV1Field.MSPA_SERVICE_PROVIDER_MODE)).getValue();
     Integer mspaOptOutOptionMode =
@@ -141,25 +144,27 @@ public class UsUtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
       }
     }
 
-    if (mspaServiceProviderMode == 0) {
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usut mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 1) {
-      if (mspaOptOutOptionMode != 2) {
-        throw new ValidationException("Invalid usut mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
-      }
+    if (mspaCoveredTransaction != 2) {
+      if (mspaServiceProviderMode == 0) {
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usut mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 1) {
+        if (mspaOptOutOptionMode != 2) {
+          throw new ValidationException("Invalid usut mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
 
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usut mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 2) {
-      if (mspaOptOutOptionMode != 1) {
-        throw new ValidationException("Invalid usut mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usut mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 2) {
+        if (mspaOptOutOptionMode != 1) {
+          throw new ValidationException("Invalid usut mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
       }
     }
   }

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsUtV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsUtV1CoreSegment.java
@@ -130,12 +130,12 @@ public class UsUtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 1) {
-      if (saleOptOut != 1 && saleOptOut != 2) {
+      if (targetedAdvertisingOptOut != 1 && targetedAdvertisingOptOut != 2) {
         throw new ValidationException("Invalid usut targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 2) {
-      if (saleOptOut != 1) {
+      if (targetedAdvertisingOptOut != 1) {
         throw new ValidationException("Invalid usut targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
@@ -149,7 +149,7 @@ public class UsUtV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
     } else if (mspaServiceProviderMode == 1) {
       if (mspaOptOutOptionMode != 2) {
         throw new ValidationException("Invalid usut mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaServiceProviderMode + "}");
+            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
       }
 
       if (saleOptOutNotice != 0) {

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsVaV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsVaV1CoreSegment.java
@@ -3,6 +3,7 @@ package com.iab.gpp.encoder.segment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+
 import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
 import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
 import com.iab.gpp.encoder.bitstring.BitStringEncoder;
@@ -100,6 +101,8 @@ public class UsVaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
         ((EncodableFixedInteger) fields.get(UsVaV1Field.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).getValue();
     Integer targetedAdvertisingOptOut =
         ((EncodableFixedInteger) fields.get(UsVaV1Field.TARGETED_ADVERTISING_OPT_OUT)).getValue();
+    Integer mspaCoveredTransaction =
+        ((EncodableFixedInteger) fields.get(UsVaV1Field.MSPA_COVERED_TRANSACTION)).getValue();
     Integer mspaServiceProviderMode =
         ((EncodableFixedInteger) fields.get(UsVaV1Field.MSPA_SERVICE_PROVIDER_MODE)).getValue();
     Integer mspaOptOutOptionMode =
@@ -139,25 +142,27 @@ public class UsVaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
       }
     }
 
-    if (mspaServiceProviderMode == 0) {
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usva mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 1) {
-      if (mspaOptOutOptionMode != 2) {
-        throw new ValidationException("Invalid usva mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
-      }
+    if (mspaCoveredTransaction != 2) {
+      if (mspaServiceProviderMode == 0) {
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usva mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 1) {
+        if (mspaOptOutOptionMode != 2) {
+          throw new ValidationException("Invalid usva mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
 
-      if (saleOptOutNotice != 0) {
-        throw new ValidationException("Invalid usva mspa service provider mode / sale opt out notice combination: {"
-            + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
-      }
-    } else if (mspaServiceProviderMode == 2) {
-      if (mspaOptOutOptionMode != 1) {
-        throw new ValidationException("Invalid usva mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        if (saleOptOutNotice != 0) {
+          throw new ValidationException("Invalid usva mspa service provider mode / sale opt out notice combination: {"
+                                        + mspaServiceProviderMode + " / " + saleOptOutNotice + "}");
+        }
+      } else if (mspaServiceProviderMode == 2) {
+        if (mspaOptOutOptionMode != 1) {
+          throw new ValidationException("Invalid usva mspa service provider / opt out option modes combination: {"
+                                        + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
+        }
       }
     }
   }

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsVaV1CoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsVaV1CoreSegment.java
@@ -128,12 +128,12 @@ public class UsVaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 1) {
-      if (saleOptOut != 1 && saleOptOut != 2) {
+      if (targetedAdvertisingOptOut != 1 && targetedAdvertisingOptOut != 2) {
         throw new ValidationException("Invalid usva targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
     } else if (targetedAdvertisingOptOutNotice == 2) {
-      if (saleOptOut != 1) {
+      if (targetedAdvertisingOptOut != 1) {
         throw new ValidationException("Invalid usva targeted advertising notice / opt out combination: {"
             + targetedAdvertisingOptOutNotice + " / " + targetedAdvertisingOptOut + "}");
       }
@@ -147,7 +147,7 @@ public class UsVaV1CoreSegment extends AbstractLazilyEncodableSegment<EncodableB
     } else if (mspaServiceProviderMode == 1) {
       if (mspaOptOutOptionMode != 2) {
         throw new ValidationException("Invalid usva mspa service provider / opt out option modes combination: {"
-            + mspaServiceProviderMode + " / " + mspaServiceProviderMode + "}");
+            + mspaServiceProviderMode + " / " + mspaOptOutOptionMode + "}");
       }
 
       if (saleOptOutNotice != 0) {


### PR DESCRIPTION
Only run validation against `mspaServiceProviderMode` when `mspaCoveredTransaction` is a value other than `2` (NO).
Currently validation will require certain variables to be set/validated but they may not be applicable in certain contexts.