### PR TITLE
Update dirty flag on modifying section values

### DIFF
--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/AbstractLazilyEncodableSection.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/AbstractLazilyEncodableSection.java
@@ -65,6 +65,7 @@ public abstract class AbstractLazilyEncodableSection implements EncodableSection
     for(EncodableSegment segment : segments) {
       if(segment.hasField(fieldName)) {
         segment.setFieldValue(fieldName, value);
+        this.dirty = true;
         return;
       }
     }


### PR DESCRIPTION
Today when we make any changes to any section in `Gppmodel` object, its not getting reflected while we encoding back.
And root cause for this issue is, dirty flag is not getting updated properly on `setFieldValue` method.

@chuff could you please review this.

Issue can be reproduced with below steps
```
GppModel gppModel = new GppModel("DBABBg~BVoIgACY.QA");
// Ideally, this should cause validation failure
// Reference: https://github.com/IABTechLab/iabgpp-java/blob/fcd606121f5795080620099a9dc51dac0482f46f/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsCaV1CoreSegment.java#L110-L115
gppModel.setFieldValue(UsCaV1.NAME, UsCaV1Field.SHARING_OPT_OUT_NOTICE, 0);
gppModel.setFieldValue(UsCaV1.NAME, UsCaV1Field.SHARING_OPT_OUT, 1);
String encodedString = gppModel.encode();
```