### PR TITLE
Fix javadoc build issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
           distribution: 'adopt'
+          java-version: '21'
 
       # Import GPG secret key for signing
       - name: Import GPG key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         languages: java
     - name: Build with Maven
       timeout-minutes: 15
-      run: mvn -B clean package --file pom.xml
+      run: mvn -B clean javadoc:javadoc package --file pom.xml
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        distribution: 'temurin'
+        distribution: 'adopt'
         java-version: '21'
         cache: 'maven'
     - name: Initialize CodeQL


### PR DESCRIPTION
- use consistent JDK (Adopt 21 LTS)
- ensure javadoc step is ran during CI build job