### PR TITLE
4.X: Set baseline to Java 11

### DIFF
--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
@@ -283,13 +283,13 @@ public class GppModel extends AbstractEncodable {
 
   @Override
   protected void doDecode(CharSequence str) {
-    if (str == null || str.isEmpty() || (str.charAt(0) == 'D' && str.charAt(1) == 'B')) {
+    if (str == null || str.length() == 0 || (str.charAt(0) == 'D' && str.charAt(1) == 'B')) {
       if (!sections.isEmpty()) {
         sections.clear();
         header.getSectionsIds().clear();
       }
 
-      if (str != null && !str.isEmpty()) {
+      if (str != null && str.length() != 0) {
         List<CharSequence> encodedSections = SlicedCharSequence.split(str, '~');
         header.decode(encodedSections.get(0));
 

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/SlicedCharSequence.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/SlicedCharSequence.java
@@ -38,7 +38,11 @@ public final class SlicedCharSequence implements CharSequence {
     }
     List<CharSequence> out = null;
     int next = 0;
-    while ((next = base.indexOf(splitter, start, end)) != -1) {
+    // TODO: use base.indexOf(splitter, start, end) if the JDK baseline is set to above 21
+    while ((next = base.indexOf(splitter, start)) != -1) {
+      if (next >= end) {
+        break;
+      }
       if (out == null) {
         // most sections/segments have less than 4 components
         out = new ArrayList<>(4);

--- a/pom.xml
+++ b/pom.xml
@@ -51,16 +51,47 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.15.0</version>
+                    <configuration>
+                        <release>${maven.compiler.release}</release>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.5.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.6.3</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-java-and-maven</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireJavaVersion>
+                                        <version>[11,)</version>
+                                    </requireJavaVersion>
+                                    <requireMavenVersion>
+                                        <version>[3.9.0,)</version>
+                                    </requireMavenVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -84,7 +115,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <java>
                             <googleJavaFormat>
@@ -105,7 +136,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.0</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -119,7 +150,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <show>public</show>
                     </configuration>
@@ -136,7 +167,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>3.2.8</version>
                     <executions>
                         <execution>
                             <id>sign-artifacts</id>
@@ -149,6 +180,16 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
- supersedes https://github.com/IABTechLab/iabgpp-java/pull/97
- upgrade code to actually target version 11, despite gh runner being greater version.
- bump maven plugin versions