### PR TITLE
Add UsKy section (Kentucky, Section ID 26)

### DIFF
--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
@@ -101,6 +101,9 @@ public class GppModel {
       } else if (sectionName.equals(UsMn.NAME)) {
         section = new UsMn();
         this.sections.put(UsMn.NAME, section);
+      } else if (sectionName.equals(UsKy.NAME)) {
+        section = new UsKy();
+        this.sections.put(UsKy.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);
@@ -302,6 +305,10 @@ public class GppModel {
     return (UsMn) getSection(UsMn.NAME);
   }
 
+  public UsKy getUsKySection() {
+    return (UsKy) getSection(UsKy.NAME);
+  }
+
   public List<Integer> getSectionIds() {
     if (!this.decoded) {
       this.sections = this.decodeModel(this.encodedString);
@@ -416,6 +423,9 @@ public class GppModel {
           } else if (sectionIds.get(i).equals(UsMn.ID)) {
             UsMn section = new UsMn(encodedSections[i + 1]);
             sections.put(UsMn.NAME, section);
+          } else if (sectionIds.get(i).equals(UsKy.ID)) {
+            UsKy section = new UsKy(encodedSections[i + 1]);
+            sections.put(UsKy.NAME, section);
           }
         }
       }
@@ -529,6 +539,9 @@ public class GppModel {
       }else if (sectionName.equals(UsMn.NAME)) {
         section = new UsMn();
         this.sections.put(UsMn.NAME, section);
+      }else if (sectionName.equals(UsKy.NAME)) {
+        section = new UsKy();
+        this.sections.put(UsKy.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsKyField.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsKyField.java
@@ -1,0 +1,46 @@
+package com.iab.gpp.encoder.field;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsKyField {
+
+  public static String MSPA_VERSION = "MspaVersion";
+  public static String MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction";
+  public static String MSPA_MODE = "MspaMode";
+  public static String PROCESSING_NOTICE = "ProcessingNotice";
+  public static String SALE_OPT_OUT_NOTICE = "SaleOptOutNotice";
+  public static String TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice";
+  public static String SALE_OPT_OUT = "SaleOptOut";
+  public static String TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut";
+  public static String KNOWN_CHILD_SENSITIVE_DATA_CONSENTS = "KnownChildSensitiveDataConsents";
+  public static String ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent";
+  public static String SENSITIVE_DATA_PROCESSING = "SensitiveDataProcessing";
+
+  public static String GPC_SEGMENT_TYPE = "GpcSegmentType";
+  public static String GPC_SEGMENT_INCLUDED = "GpcSegmentIncluded";
+  public static String GPC = "Gpc";
+
+  //@formatter:off
+  public static List<String> USKY_CORE_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsKyField.MSPA_VERSION,
+      UsKyField.MSPA_COVERED_TRANSACTION,
+      UsKyField.MSPA_MODE,
+      UsKyField.PROCESSING_NOTICE,
+      UsKyField.SALE_OPT_OUT_NOTICE,
+      UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+      UsKyField.SALE_OPT_OUT,
+      UsKyField.TARGETED_ADVERTISING_OPT_OUT,
+      UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+      UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+      UsKyField.SENSITIVE_DATA_PROCESSING
+  });
+  //@formatter:on
+
+  //@formatter:off
+  public static List<String> USKY_GPC_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsKyField.GPC_SEGMENT_TYPE,
+      UsKyField.GPC
+  });
+  //@formatter:on
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/Sections.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/Sections.java
@@ -35,6 +35,7 @@ public class Sections {
     SECTION_ID_NAME_MAP.put(UsNj.ID, UsNj.NAME);
     SECTION_ID_NAME_MAP.put(UsTn.ID, UsTn.NAME);
     SECTION_ID_NAME_MAP.put(UsMn.ID, UsMn.NAME);
+    SECTION_ID_NAME_MAP.put(UsKy.ID, UsKy.NAME);
 
     SECTION_ORDER = new ArrayList<Integer>(SECTION_ID_NAME_MAP.keySet()).stream().sorted()
         .map(id -> SECTION_ID_NAME_MAP.get(id)).collect(Collectors.toList());

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsKy.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsKy.java
@@ -1,0 +1,140 @@
+package com.iab.gpp.encoder.section;
+
+import com.iab.gpp.encoder.field.UsKyField;
+import com.iab.gpp.encoder.segment.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsKy extends AbstractLazilyEncodableSection {
+
+  public static int ID = 26;
+  public static int VERSION = 1;
+  public static String NAME = "usky";
+
+  public UsKy() {
+    super();
+  }
+
+  public UsKy(String encodedString) {
+    super();
+    decode(encodedString);
+  }
+
+  @Override
+  public int getId() {
+    return UsKy.ID;
+  }
+
+  @Override
+  public String getName() {
+    return UsKy.NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return UsKy.VERSION;
+  }
+
+  @Override
+  protected List<EncodableSegment> initializeSegments() {
+    List<EncodableSegment> segments = new ArrayList<>();
+    segments.add(new UsKyCoreSegment());
+    segments.add(new UsKyGpcSegment());
+    return segments;
+  }
+
+  @Override
+  protected List<EncodableSegment> decodeSection(String encodedString) {
+    List<EncodableSegment> segments = initializeSegments();
+
+    if (encodedString != null && !encodedString.isEmpty()) {
+      String[] encodedSegments = encodedString.split("\\.");
+
+      if (encodedSegments.length > 0) {
+        segments.get(0).decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments.get(1).setFieldValue(UsKyField.GPC_SEGMENT_INCLUDED, true);
+        segments.get(1).decode(encodedSegments[1]);
+      } else {
+        segments.get(1).setFieldValue(UsKyField.GPC_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  @Override
+  protected String encodeSection(List<EncodableSegment> segments) {
+    List<String> encodedSegments = new ArrayList<>();
+
+    if (!segments.isEmpty()) {
+      encodedSegments.add(segments.get(0).encode());
+      if (segments.size() >= 2 && segments.get(1).getFieldValue(UsKyField.GPC_SEGMENT_INCLUDED).equals(true)) {
+        encodedSegments.add(segments.get(1).encode());
+      }
+    }
+
+    return String.join(".", encodedSegments);
+  }
+
+
+  public Integer getMspaVersion() {
+    return (Integer) this.getFieldValue(UsKyField.MSPA_VERSION);
+  }
+
+  public Integer getMspaCoveredTransaction() {
+    return (Integer) this.getFieldValue(UsKyField.MSPA_COVERED_TRANSACTION);
+  }
+
+  public Integer getMspaMode() {
+    return (Integer) this.getFieldValue(UsKyField.MSPA_MODE);
+  }
+
+  public Integer getProcessingNotice() {
+    return (Integer) this.getFieldValue(UsKyField.PROCESSING_NOTICE);
+  }
+
+  public Integer getSaleOptOutNotice() {
+    return (Integer) this.getFieldValue(UsKyField.SALE_OPT_OUT_NOTICE);
+  }
+
+  public Integer getTargetedAdvertisingOptOutNotice() {
+    return (Integer) this.getFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE);
+  }
+
+  public Integer getSaleOptOut() {
+    return (Integer) this.getFieldValue(UsKyField.SALE_OPT_OUT);
+  }
+
+  public Integer getTargetedAdvertisingOptOut() {
+    return (Integer) this.getFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT);
+  }
+
+  public Integer getKnownChildSensitiveDataConsents() {
+    return (Integer) this.getFieldValue(UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS);
+  }
+
+  public Integer getAdditionalDataProcessingConsent() {
+    return (Integer) this.getFieldValue(UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Integer> getSensitiveDataProcessing() {
+    return (List<Integer>) this.getFieldValue(UsKyField.SENSITIVE_DATA_PROCESSING);
+  }
+
+  public Integer getGpcSegmentType() {
+    return (Integer) this.getFieldValue(UsKyField.GPC_SEGMENT_TYPE);
+  }
+
+  public Boolean getGpcSegmentIncluded() {
+    return (Boolean) this.getFieldValue(UsKyField.GPC_SEGMENT_INCLUDED);
+  }
+
+  public Boolean getGpc() {
+    return (Boolean) this.getFieldValue(UsKyField.GPC);
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKyCoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKyCoreSegment.java
@@ -1,0 +1,95 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.datatype.EncodableFixedIntegerList;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsKyField;
+import com.iab.gpp.encoder.section.UsKy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsKyCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsKyCoreSegment() {
+    super();
+  }
+
+  public UsKyCoreSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsKyField.USKY_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<Integer> nullableBooleanAsTwoBitIntegerValidator = (n -> n >= 0 && n <= 2);
+    Predicate<Integer> nonNullableBooleanAsTwoBitIntegerValidator = (n -> n >= 1 && n <= 2);
+    Predicate<List<Integer>> nullableBooleanAsTwoBitIntegerListValidator = (l -> {
+      for (int n : l) {
+        if (n < 0 || n > 2) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsKyField.MSPA_VERSION, new EncodableFixedInteger(6, UsKy.VERSION));
+    fields.put(UsKyField.MSPA_COVERED_TRANSACTION,
+        new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.MSPA_MODE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.PROCESSING_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.SALE_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.SALE_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.TARGETED_ADVERTISING_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.SENSITIVE_DATA_PROCESSING,
+        new EncodableFixedIntegerList(2, Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0))
+            .withValidator(nullableBooleanAsTwoBitIntegerListValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsKyCoreSegment '" + encodedString + "'", e);
+    }
+  }
+
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKyGpcSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKyGpcSegment.java
@@ -1,0 +1,61 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableBoolean;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsKyField;
+
+import java.util.List;
+
+public class UsKyGpcSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsKyGpcSegment() {
+    super();
+  }
+
+  public UsKyGpcSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsKyField.USKY_GPC_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsKyField.GPC_SEGMENT_TYPE, new EncodableFixedInteger(2, 1));
+    fields.put(UsKyField.GPC_SEGMENT_INCLUDED, new EncodableBoolean(true));
+    fields.put(UsKyField.GPC, new EncodableBoolean(false));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if(encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsKyGpcSegment '" + encodedString + "'", e);
+    }
+  }
+}

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/GppModelTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/GppModelTest.java
@@ -17,6 +17,7 @@ import com.iab.gpp.encoder.section.UsCt;
 import com.iab.gpp.encoder.section.UsDe;
 import com.iab.gpp.encoder.section.UsFl;
 import com.iab.gpp.encoder.section.UsIa;
+import com.iab.gpp.encoder.section.UsKy;
 import com.iab.gpp.encoder.section.UsMn;
 import com.iab.gpp.encoder.section.UsMt;
 import com.iab.gpp.encoder.section.UsNat;
@@ -83,6 +84,7 @@ public class GppModelTest {
     Assertions.assertEquals(false, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(false, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(false, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(false, gppModel.hasSection(UsKy.NAME));
 
     gppModel.setFieldValue(TcfEuV2.NAME, TcfEuV2Field.VERSION, TcfEuV2.VERSION);
     gppModel.setFieldValue(TcfEuV2.NAME, TcfCaV1Field.CREATED, utcDateTime);
@@ -108,6 +110,7 @@ public class GppModelTest {
     gppModel.setFieldValue(UsNj.NAME, UsNjField.VERSION, UsNj.VERSION);
     gppModel.setFieldValue(UsTn.NAME, UsTnField.VERSION, UsTn.VERSION);
     gppModel.setFieldValue(UsMn.NAME, UsMnField.VERSION, UsMn.VERSION);
+    gppModel.setFieldValue(UsKy.NAME, UsKyField.MSPA_VERSION, UsKy.VERSION);
 
 
     Assertions.assertEquals(true, gppModel.hasSection(TcfEuV2.NAME));
@@ -130,10 +133,11 @@ public class GppModelTest {
     Assertions.assertEquals(true, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsKy.NAME));
 
     String gppString = gppModel.encode();
     Assertions.assertEquals(
-            "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA",
+            "DBADOYsY~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAAAAA.QA",
             gppString);
   }
 
@@ -406,7 +410,7 @@ public class GppModelTest {
   @Test
   public void testDecodeDefaultsAll() {
     String gppString =
-        "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAABAA.QA";
+        "DBADOYsY~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAAAAA.QA";
     GppModel gppModel = new GppModel(gppString);
 
     Assertions.assertEquals(true, gppModel.hasSection(TcfEuV2.NAME));
@@ -429,6 +433,7 @@ public class GppModelTest {
     Assertions.assertEquals(true, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsKy.NAME));
   }
 
   @Test

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsKyTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsKyTest.java
@@ -1,0 +1,88 @@
+package com.iab.gpp.encoder.section;
+
+
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.error.ValidationException;
+import com.iab.gpp.encoder.field.UsKyField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class UsKyTest {
+
+  @Test
+  public void testEncode1() {
+    UsKy usKy = new UsKy();
+    Assertions.assertEquals("BQAAAAA.QA", usKy.encode());
+  }
+
+  @Test
+  public void testEncode2() {
+    UsKy usKy = new UsKy();
+
+    usKy.setFieldValue(UsKyField.MSPA_COVERED_TRANSACTION, 1);
+    usKy.setFieldValue(UsKyField.MSPA_MODE, 1);
+    usKy.setFieldValue(UsKyField.PROCESSING_NOTICE, 1);
+    usKy.setFieldValue(UsKyField.SALE_OPT_OUT_NOTICE, 1);
+    usKy.setFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usKy.setFieldValue(UsKyField.SALE_OPT_OUT, 1);
+    usKy.setFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usKy.setFieldValue(UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 1);
+    usKy.setFieldValue(UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usKy.setFieldValue(UsKyField.SENSITIVE_DATA_PROCESSING, Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1));
+    usKy.setFieldValue(UsKyField.GPC, true);
+
+    Assertions.assertEquals("BVVVkkk.YA", usKy.encode());
+  }
+
+  @Test
+  public void testSetInvalidValues() {
+    UsKy usKy = new UsKy();
+
+    try {
+      usKy.setFieldValue(UsKyField.MSPA_COVERED_TRANSACTION, 0);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usKy.setFieldValue(UsKyField.MSPA_MODE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usKy.setFieldValue(UsKyField.SENSITIVE_DATA_PROCESSING, Arrays.asList(0, 1, 2, 3, 1, 2, 0, 1));
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+  }
+
+  @Test
+  public void testEncodeWithGpcSegmentExcluded() {
+    UsKy usKy = new UsKy();
+    usKy.setFieldValue(UsKyField.GPC_SEGMENT_INCLUDED, false);
+    Assertions.assertEquals("BQAAAAA", usKy.encode());
+  }
+
+  @Test
+  public void testDecode1() throws DecodingException {
+    UsKy usKy = new UsKy("BVVVkkk.YA");
+
+    Assertions.assertEquals(1, usKy.getMspaCoveredTransaction());
+    Assertions.assertEquals(1, usKy.getMspaMode());
+    Assertions.assertEquals(Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1), usKy.getSensitiveDataProcessing());
+    Assertions.assertEquals(true, usKy.getGpc());
+  }
+
+  @Test()
+  public void testDecodeGarbage() {
+    Assertions.assertThrows(DecodingException.class, () -> {
+      new UsKy("z").getProcessingNotice();
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Kentucky section per the GPP US-States/KY spec, registered as Section ID 26 (client-side API prefix `usky`).

- Adds `UsKy` section, `UsKyField` constants, `UsKyCoreSegment`, `UsKyGpcSegment` following the existing `UsMn` pattern.
- Registers the section in `Sections.java` and `GppModel.java` (encode/decode dispatch + `getUsKySection()` accessor).
- Core subsection has 11 fields including `SensitiveDataProcessing` (N-Bitfield(2,8)) and `KnownChildSensitiveDataConsents`. The single `MspaMode` field replaces `MspaOptOutOptionMode` + `MspaServiceProviderMode`, and `MspaVersion` is the first field.

## Test plan

- [x] Added `UsKyTest` covering encode default, encode all fields, validation rejection, GPC-segment exclusion, round-trip decode, and garbage input
- [x] Updated `GppModelTest.testEncodeDefaultAll` and `testDecodeDefaultsAll` to include UsKy
- [x] `mvn test` on `iabgpp-encoder`: **370 passing**