### PR TITLE
Add UsRi section (Rhode Island, Section ID 27)

### DIFF
--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
@@ -101,6 +101,9 @@ public class GppModel {
       } else if (sectionName.equals(UsMn.NAME)) {
         section = new UsMn();
         this.sections.put(UsMn.NAME, section);
+      } else if (sectionName.equals(UsRi.NAME)) {
+        section = new UsRi();
+        this.sections.put(UsRi.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);
@@ -302,6 +305,10 @@ public class GppModel {
     return (UsMn) getSection(UsMn.NAME);
   }
 
+  public UsRi getUsRiSection() {
+    return (UsRi) getSection(UsRi.NAME);
+  }
+
   public List<Integer> getSectionIds() {
     if (!this.decoded) {
       this.sections = this.decodeModel(this.encodedString);
@@ -416,6 +423,9 @@ public class GppModel {
           } else if (sectionIds.get(i).equals(UsMn.ID)) {
             UsMn section = new UsMn(encodedSections[i + 1]);
             sections.put(UsMn.NAME, section);
+          } else if (sectionIds.get(i).equals(UsRi.ID)) {
+            UsRi section = new UsRi(encodedSections[i + 1]);
+            sections.put(UsRi.NAME, section);
           }
         }
       }
@@ -529,6 +539,9 @@ public class GppModel {
       }else if (sectionName.equals(UsMn.NAME)) {
         section = new UsMn();
         this.sections.put(UsMn.NAME, section);
+      }else if (sectionName.equals(UsRi.NAME)) {
+        section = new UsRi();
+        this.sections.put(UsRi.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsRiField.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsRiField.java
@@ -1,0 +1,46 @@
+package com.iab.gpp.encoder.field;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsRiField {
+
+  public static String MSPA_VERSION = "MspaVersion";
+  public static String MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction";
+  public static String MSPA_MODE = "MspaMode";
+  public static String PROCESSING_NOTICE = "ProcessingNotice";
+  public static String SALE_OPT_OUT_NOTICE = "SaleOptOutNotice";
+  public static String TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice";
+  public static String SALE_OPT_OUT = "SaleOptOut";
+  public static String TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut";
+  public static String KNOWN_CHILD_SENSITIVE_DATA_CONSENTS = "KnownChildSensitiveDataConsents";
+  public static String ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent";
+  public static String SENSITIVE_DATA_PROCESSING = "SensitiveDataProcessing";
+
+  public static String GPC_SEGMENT_TYPE = "GpcSegmentType";
+  public static String GPC_SEGMENT_INCLUDED = "GpcSegmentIncluded";
+  public static String GPC = "Gpc";
+
+  //@formatter:off
+  public static List<String> USRI_CORE_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsRiField.MSPA_VERSION,
+      UsRiField.MSPA_COVERED_TRANSACTION,
+      UsRiField.MSPA_MODE,
+      UsRiField.PROCESSING_NOTICE,
+      UsRiField.SALE_OPT_OUT_NOTICE,
+      UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+      UsRiField.SALE_OPT_OUT,
+      UsRiField.TARGETED_ADVERTISING_OPT_OUT,
+      UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+      UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+      UsRiField.SENSITIVE_DATA_PROCESSING
+  });
+  //@formatter:on
+
+  //@formatter:off
+  public static List<String> USRI_GPC_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsRiField.GPC_SEGMENT_TYPE,
+      UsRiField.GPC
+  });
+  //@formatter:on
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/Sections.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/Sections.java
@@ -35,6 +35,7 @@ public class Sections {
     SECTION_ID_NAME_MAP.put(UsNj.ID, UsNj.NAME);
     SECTION_ID_NAME_MAP.put(UsTn.ID, UsTn.NAME);
     SECTION_ID_NAME_MAP.put(UsMn.ID, UsMn.NAME);
+    SECTION_ID_NAME_MAP.put(UsRi.ID, UsRi.NAME);
 
     SECTION_ORDER = new ArrayList<Integer>(SECTION_ID_NAME_MAP.keySet()).stream().sorted()
         .map(id -> SECTION_ID_NAME_MAP.get(id)).collect(Collectors.toList());

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsRi.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsRi.java
@@ -1,0 +1,140 @@
+package com.iab.gpp.encoder.section;
+
+import com.iab.gpp.encoder.field.UsRiField;
+import com.iab.gpp.encoder.segment.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsRi extends AbstractLazilyEncodableSection {
+
+  public static int ID = 27;
+  public static int VERSION = 1;
+  public static String NAME = "usri";
+
+  public UsRi() {
+    super();
+  }
+
+  public UsRi(String encodedString) {
+    super();
+    decode(encodedString);
+  }
+
+  @Override
+  public int getId() {
+    return UsRi.ID;
+  }
+
+  @Override
+  public String getName() {
+    return UsRi.NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return UsRi.VERSION;
+  }
+
+  @Override
+  protected List<EncodableSegment> initializeSegments() {
+    List<EncodableSegment> segments = new ArrayList<>();
+    segments.add(new UsRiCoreSegment());
+    segments.add(new UsRiGpcSegment());
+    return segments;
+  }
+
+  @Override
+  protected List<EncodableSegment> decodeSection(String encodedString) {
+    List<EncodableSegment> segments = initializeSegments();
+
+    if (encodedString != null && !encodedString.isEmpty()) {
+      String[] encodedSegments = encodedString.split("\\.");
+
+      if (encodedSegments.length > 0) {
+        segments.get(0).decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments.get(1).setFieldValue(UsRiField.GPC_SEGMENT_INCLUDED, true);
+        segments.get(1).decode(encodedSegments[1]);
+      } else {
+        segments.get(1).setFieldValue(UsRiField.GPC_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  @Override
+  protected String encodeSection(List<EncodableSegment> segments) {
+    List<String> encodedSegments = new ArrayList<>();
+
+    if (!segments.isEmpty()) {
+      encodedSegments.add(segments.get(0).encode());
+      if (segments.size() >= 2 && segments.get(1).getFieldValue(UsRiField.GPC_SEGMENT_INCLUDED).equals(true)) {
+        encodedSegments.add(segments.get(1).encode());
+      }
+    }
+
+    return String.join(".", encodedSegments);
+  }
+
+
+  public Integer getMspaVersion() {
+    return (Integer) this.getFieldValue(UsRiField.MSPA_VERSION);
+  }
+
+  public Integer getMspaCoveredTransaction() {
+    return (Integer) this.getFieldValue(UsRiField.MSPA_COVERED_TRANSACTION);
+  }
+
+  public Integer getMspaMode() {
+    return (Integer) this.getFieldValue(UsRiField.MSPA_MODE);
+  }
+
+  public Integer getProcessingNotice() {
+    return (Integer) this.getFieldValue(UsRiField.PROCESSING_NOTICE);
+  }
+
+  public Integer getSaleOptOutNotice() {
+    return (Integer) this.getFieldValue(UsRiField.SALE_OPT_OUT_NOTICE);
+  }
+
+  public Integer getTargetedAdvertisingOptOutNotice() {
+    return (Integer) this.getFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE);
+  }
+
+  public Integer getSaleOptOut() {
+    return (Integer) this.getFieldValue(UsRiField.SALE_OPT_OUT);
+  }
+
+  public Integer getTargetedAdvertisingOptOut() {
+    return (Integer) this.getFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT);
+  }
+
+  public Integer getKnownChildSensitiveDataConsents() {
+    return (Integer) this.getFieldValue(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS);
+  }
+
+  public Integer getAdditionalDataProcessingConsent() {
+    return (Integer) this.getFieldValue(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Integer> getSensitiveDataProcessing() {
+    return (List<Integer>) this.getFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING);
+  }
+
+  public Integer getGpcSegmentType() {
+    return (Integer) this.getFieldValue(UsRiField.GPC_SEGMENT_TYPE);
+  }
+
+  public Boolean getGpcSegmentIncluded() {
+    return (Boolean) this.getFieldValue(UsRiField.GPC_SEGMENT_INCLUDED);
+  }
+
+  public Boolean getGpc() {
+    return (Boolean) this.getFieldValue(UsRiField.GPC);
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiCoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiCoreSegment.java
@@ -1,0 +1,95 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.datatype.EncodableFixedIntegerList;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsRiField;
+import com.iab.gpp.encoder.section.UsRi;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsRiCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsRiCoreSegment() {
+    super();
+  }
+
+  public UsRiCoreSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsRiField.USRI_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<Integer> nullableBooleanAsTwoBitIntegerValidator = (n -> n >= 0 && n <= 2);
+    Predicate<Integer> nonNullableBooleanAsTwoBitIntegerValidator = (n -> n >= 1 && n <= 2);
+    Predicate<List<Integer>> nullableBooleanAsTwoBitIntegerListValidator = (l -> {
+      for (int n : l) {
+        if (n < 0 || n > 2) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsRiField.MSPA_VERSION, new EncodableFixedInteger(6, UsRi.VERSION));
+    fields.put(UsRiField.MSPA_COVERED_TRANSACTION,
+        new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.MSPA_MODE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.PROCESSING_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.SALE_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.SALE_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.TARGETED_ADVERTISING_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.SENSITIVE_DATA_PROCESSING,
+        new EncodableFixedIntegerList(2, Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0))
+            .withValidator(nullableBooleanAsTwoBitIntegerListValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsRiCoreSegment '" + encodedString + "'", e);
+    }
+  }
+
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiGpcSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiGpcSegment.java
@@ -1,0 +1,61 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableBoolean;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsRiField;
+
+import java.util.List;
+
+public class UsRiGpcSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsRiGpcSegment() {
+    super();
+  }
+
+  public UsRiGpcSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsRiField.USRI_GPC_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsRiField.GPC_SEGMENT_TYPE, new EncodableFixedInteger(2, 1));
+    fields.put(UsRiField.GPC_SEGMENT_INCLUDED, new EncodableBoolean(true));
+    fields.put(UsRiField.GPC, new EncodableBoolean(false));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if(encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsRiGpcSegment '" + encodedString + "'", e);
+    }
+  }
+}

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/GppModelTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/GppModelTest.java
@@ -24,6 +24,7 @@ import com.iab.gpp.encoder.section.UsNe;
 import com.iab.gpp.encoder.section.UsNh;
 import com.iab.gpp.encoder.section.UsNj;
 import com.iab.gpp.encoder.section.UsOr;
+import com.iab.gpp.encoder.section.UsRi;
 import com.iab.gpp.encoder.section.UsTn;
 import com.iab.gpp.encoder.section.UsTx;
 import com.iab.gpp.encoder.section.UsUt;
@@ -83,6 +84,7 @@ public class GppModelTest {
     Assertions.assertEquals(false, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(false, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(false, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(false, gppModel.hasSection(UsRi.NAME));
 
     gppModel.setFieldValue(TcfEuV2.NAME, TcfEuV2Field.VERSION, TcfEuV2.VERSION);
     gppModel.setFieldValue(TcfEuV2.NAME, TcfCaV1Field.CREATED, utcDateTime);
@@ -108,6 +110,7 @@ public class GppModelTest {
     gppModel.setFieldValue(UsNj.NAME, UsNjField.VERSION, UsNj.VERSION);
     gppModel.setFieldValue(UsTn.NAME, UsTnField.VERSION, UsTn.VERSION);
     gppModel.setFieldValue(UsMn.NAME, UsMnField.VERSION, UsMn.VERSION);
+    gppModel.setFieldValue(UsRi.NAME, UsRiField.MSPA_VERSION, UsRi.VERSION);
 
 
     Assertions.assertEquals(true, gppModel.hasSection(TcfEuV2.NAME));
@@ -130,10 +133,11 @@ public class GppModelTest {
     Assertions.assertEquals(true, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsRi.NAME));
 
     String gppString = gppModel.encode();
     Assertions.assertEquals(
-            "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA",
+            "DBADOYtY~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAAAAA.QA",
             gppString);
   }
 
@@ -406,7 +410,7 @@ public class GppModelTest {
   @Test
   public void testDecodeDefaultsAll() {
     String gppString =
-        "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAABAA.QA";
+        "DBADOYtY~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAAAAA.QA";
     GppModel gppModel = new GppModel(gppString);
 
     Assertions.assertEquals(true, gppModel.hasSection(TcfEuV2.NAME));
@@ -429,6 +433,7 @@ public class GppModelTest {
     Assertions.assertEquals(true, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsRi.NAME));
   }
 
   @Test

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsRiTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsRiTest.java
@@ -1,0 +1,88 @@
+package com.iab.gpp.encoder.section;
+
+
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.error.ValidationException;
+import com.iab.gpp.encoder.field.UsRiField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class UsRiTest {
+
+  @Test
+  public void testEncode1() {
+    UsRi usRi = new UsRi();
+    Assertions.assertEquals("BQAAAAA.QA", usRi.encode());
+  }
+
+  @Test
+  public void testEncode2() {
+    UsRi usRi = new UsRi();
+
+    usRi.setFieldValue(UsRiField.MSPA_COVERED_TRANSACTION, 1);
+    usRi.setFieldValue(UsRiField.MSPA_MODE, 1);
+    usRi.setFieldValue(UsRiField.PROCESSING_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.SALE_OPT_OUT_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.SALE_OPT_OUT, 1);
+    usRi.setFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usRi.setFieldValue(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 1);
+    usRi.setFieldValue(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usRi.setFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING, Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1));
+    usRi.setFieldValue(UsRiField.GPC, true);
+
+    Assertions.assertEquals("BVVVkkk.YA", usRi.encode());
+  }
+
+  @Test
+  public void testSetInvalidValues() {
+    UsRi usRi = new UsRi();
+
+    try {
+      usRi.setFieldValue(UsRiField.MSPA_COVERED_TRANSACTION, 0);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usRi.setFieldValue(UsRiField.MSPA_MODE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usRi.setFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING, Arrays.asList(0, 1, 2, 3, 1, 2, 0, 1));
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+  }
+
+  @Test
+  public void testEncodeWithGpcSegmentExcluded() {
+    UsRi usRi = new UsRi();
+    usRi.setFieldValue(UsRiField.GPC_SEGMENT_INCLUDED, false);
+    Assertions.assertEquals("BQAAAAA", usRi.encode());
+  }
+
+  @Test
+  public void testDecode1() throws DecodingException {
+    UsRi usRi = new UsRi("BVVVkkk.YA");
+
+    Assertions.assertEquals(1, usRi.getMspaCoveredTransaction());
+    Assertions.assertEquals(1, usRi.getMspaMode());
+    Assertions.assertEquals(Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1), usRi.getSensitiveDataProcessing());
+    Assertions.assertEquals(true, usRi.getGpc());
+  }
+
+  @Test()
+  public void testDecodeGarbage() {
+    Assertions.assertThrows(DecodingException.class, () -> {
+      new UsRi("z").getProcessingNotice();
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Rhode Island section per the GPP US-States/RI spec, registered as Section ID 27 (client-side API prefix `usri`).

- Adds `UsRi` section, `UsRiField` constants, `UsRiCoreSegment`, `UsRiGpcSegment` following the existing `UsMn` pattern.
- Registers the section in `Sections.java` and `GppModel.java` (encode/decode dispatch + `getUsRiSection()` accessor).
- Core subsection has 11 fields including `SensitiveDataProcessing` (N-Bitfield(2,8)) and `KnownChildSensitiveDataConsents`. The single `MspaMode` field replaces `MspaOptOutOptionMode` + `MspaServiceProviderMode`, and `MspaVersion` is the first field.

## Test plan

- [x] Added `UsRiTest` covering encode default, encode all fields, validation rejection, GPC-segment exclusion, round-trip decode, and garbage input
- [x] Updated `GppModelTest.testEncodeDefaultAll` and `testDecodeDefaultsAll` to include UsRi
- [x] `mvn test` on `iabgpp-encoder`: **370 passing**