### PR TITLE
Add support for Maryland (24), Indiana (25), Kentucky (26), Rhode Island (27)

### DIFF
--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/GppModel.java
@@ -101,6 +101,18 @@ public class GppModel {
       } else if (sectionName.equals(UsMn.NAME)) {
         section = new UsMn();
         this.sections.put(UsMn.NAME, section);
+      } else if (sectionName.equals(UsMd.NAME)) {
+        section = new UsMd();
+        this.sections.put(UsMd.NAME, section);
+      } else if (sectionName.equals(UsIn.NAME)) {
+        section = new UsIn();
+        this.sections.put(UsIn.NAME, section);
+      } else if (sectionName.equals(UsKy.NAME)) {
+        section = new UsKy();
+        this.sections.put(UsKy.NAME, section);
+      } else if (sectionName.equals(UsRi.NAME)) {
+        section = new UsRi();
+        this.sections.put(UsRi.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);
@@ -302,6 +314,22 @@ public class GppModel {
     return (UsMn) getSection(UsMn.NAME);
   }
 
+  public UsMd getUsMdSection() {
+    return (UsMd) getSection(UsMd.NAME);
+  }
+
+  public UsIn getUsInSection() {
+    return (UsIn) getSection(UsIn.NAME);
+  }
+
+  public UsKy getUsKySection() {
+    return (UsKy) getSection(UsKy.NAME);
+  }
+
+  public UsRi getUsRiSection() {
+    return (UsRi) getSection(UsRi.NAME);
+  }
+
   public List<Integer> getSectionIds() {
     if (!this.decoded) {
       this.sections = this.decodeModel(this.encodedString);
@@ -416,6 +444,18 @@ public class GppModel {
           } else if (sectionIds.get(i).equals(UsMn.ID)) {
             UsMn section = new UsMn(encodedSections[i + 1]);
             sections.put(UsMn.NAME, section);
+          } else if (sectionIds.get(i).equals(UsMd.ID)) {
+            UsMd section = new UsMd(encodedSections[i + 1]);
+            sections.put(UsMd.NAME, section);
+          } else if (sectionIds.get(i).equals(UsIn.ID)) {
+            UsIn section = new UsIn(encodedSections[i + 1]);
+            sections.put(UsIn.NAME, section);
+          } else if (sectionIds.get(i).equals(UsKy.ID)) {
+            UsKy section = new UsKy(encodedSections[i + 1]);
+            sections.put(UsKy.NAME, section);
+          } else if (sectionIds.get(i).equals(UsRi.ID)) {
+            UsRi section = new UsRi(encodedSections[i + 1]);
+            sections.put(UsRi.NAME, section);
           }
         }
       }
@@ -529,6 +569,18 @@ public class GppModel {
       }else if (sectionName.equals(UsMn.NAME)) {
         section = new UsMn();
         this.sections.put(UsMn.NAME, section);
+      }else if (sectionName.equals(UsMd.NAME)) {
+        section = new UsMd();
+        this.sections.put(UsMd.NAME, section);
+      }else if (sectionName.equals(UsIn.NAME)) {
+        section = new UsIn();
+        this.sections.put(UsIn.NAME, section);
+      }else if (sectionName.equals(UsKy.NAME)) {
+        section = new UsKy();
+        this.sections.put(UsKy.NAME, section);
+      }else if (sectionName.equals(UsRi.NAME)) {
+        section = new UsRi();
+        this.sections.put(UsRi.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsInField.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsInField.java
@@ -1,0 +1,42 @@
+package com.iab.gpp.encoder.field;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsInField {
+
+  public static String MSPA_VERSION = "MspaVersion";
+  public static String MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction";
+  public static String MSPA_MODE = "MspaMode";
+  public static String PROCESSING_NOTICE = "ProcessingNotice";
+  public static String SALE_OPT_OUT_NOTICE = "SaleOptOutNotice";
+  public static String TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice";
+  public static String SALE_OPT_OUT = "SaleOptOut";
+  public static String TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut";
+  public static String KNOWN_CHILD_SENSITIVE_DATA_CONSENTS = "KnownChildSensitiveDataConsents";
+  public static String ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent";
+  public static String SENSITIVE_DATA_PROCESSING = "SensitiveDataProcessing";
+
+  public static String SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED = "SensitiveDataConsentSegmentIncluded";
+
+  //@formatter:off
+  public static List<String> USIN_CORE_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsInField.MSPA_VERSION,
+      UsInField.MSPA_COVERED_TRANSACTION,
+      UsInField.MSPA_MODE,
+      UsInField.PROCESSING_NOTICE,
+      UsInField.SALE_OPT_OUT_NOTICE,
+      UsInField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+      UsInField.SALE_OPT_OUT,
+      UsInField.TARGETED_ADVERTISING_OPT_OUT,
+      UsInField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+      UsInField.ADDITIONAL_DATA_PROCESSING_CONSENT
+  });
+  //@formatter:on
+
+  //@formatter:off
+  public static List<String> USIN_SENSITIVE_DATA_CONSENT_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsInField.SENSITIVE_DATA_PROCESSING
+  });
+  //@formatter:on
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsKyField.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsKyField.java
@@ -1,0 +1,42 @@
+package com.iab.gpp.encoder.field;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsKyField {
+
+  public static String MSPA_VERSION = "MspaVersion";
+  public static String MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction";
+  public static String MSPA_MODE = "MspaMode";
+  public static String PROCESSING_NOTICE = "ProcessingNotice";
+  public static String SALE_OPT_OUT_NOTICE = "SaleOptOutNotice";
+  public static String TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice";
+  public static String SALE_OPT_OUT = "SaleOptOut";
+  public static String TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut";
+  public static String KNOWN_CHILD_SENSITIVE_DATA_CONSENTS = "KnownChildSensitiveDataConsents";
+  public static String ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent";
+  public static String SENSITIVE_DATA_PROCESSING = "SensitiveDataProcessing";
+
+  public static String SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED = "SensitiveDataConsentSegmentIncluded";
+
+  //@formatter:off
+  public static List<String> USKY_CORE_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsKyField.MSPA_VERSION,
+      UsKyField.MSPA_COVERED_TRANSACTION,
+      UsKyField.MSPA_MODE,
+      UsKyField.PROCESSING_NOTICE,
+      UsKyField.SALE_OPT_OUT_NOTICE,
+      UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+      UsKyField.SALE_OPT_OUT,
+      UsKyField.TARGETED_ADVERTISING_OPT_OUT,
+      UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+      UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT
+  });
+  //@formatter:on
+
+  //@formatter:off
+  public static List<String> USKY_SENSITIVE_DATA_CONSENT_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsKyField.SENSITIVE_DATA_PROCESSING
+  });
+  //@formatter:on
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsMdField.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsMdField.java
@@ -1,0 +1,42 @@
+package com.iab.gpp.encoder.field;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsMdField {
+
+  public static String MSPA_VERSION = "MspaVersion";
+  public static String MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction";
+  public static String MSPA_MODE = "MspaMode";
+  public static String PROCESSING_NOTICE = "ProcessingNotice";
+  public static String SALE_OPT_OUT_NOTICE = "SaleOptOutNotice";
+  public static String TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice";
+  public static String SALE_OPT_OUT = "SaleOptOut";
+  public static String TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut";
+  public static String ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent";
+
+  public static String GPC_SEGMENT_TYPE = "GpcSegmentType";
+  public static String GPC_SEGMENT_INCLUDED = "GpcSegmentIncluded";
+  public static String GPC = "Gpc";
+
+  //@formatter:off
+  public static List<String> USMD_CORE_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsMdField.MSPA_VERSION,
+      UsMdField.MSPA_COVERED_TRANSACTION,
+      UsMdField.MSPA_MODE,
+      UsMdField.PROCESSING_NOTICE,
+      UsMdField.SALE_OPT_OUT_NOTICE,
+      UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+      UsMdField.SALE_OPT_OUT,
+      UsMdField.TARGETED_ADVERTISING_OPT_OUT,
+      UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT
+  });
+  //@formatter:on
+
+  //@formatter:off
+  public static List<String> USMD_GPC_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsMdField.GPC_SEGMENT_TYPE,
+      UsMdField.GPC
+  });
+  //@formatter:on
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsRiField.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/field/UsRiField.java
@@ -1,0 +1,42 @@
+package com.iab.gpp.encoder.field;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class UsRiField {
+
+  public static String MSPA_VERSION = "MspaVersion";
+  public static String MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction";
+  public static String MSPA_MODE = "MspaMode";
+  public static String PROCESSING_NOTICE = "ProcessingNotice";
+  public static String SALE_OPT_OUT_NOTICE = "SaleOptOutNotice";
+  public static String TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice";
+  public static String SALE_OPT_OUT = "SaleOptOut";
+  public static String TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut";
+  public static String KNOWN_CHILD_SENSITIVE_DATA_CONSENTS = "KnownChildSensitiveDataConsents";
+  public static String ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent";
+  public static String SENSITIVE_DATA_PROCESSING = "SensitiveDataProcessing";
+
+  public static String SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED = "SensitiveDataConsentSegmentIncluded";
+
+  //@formatter:off
+  public static List<String> USRI_CORE_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsRiField.MSPA_VERSION,
+      UsRiField.MSPA_COVERED_TRANSACTION,
+      UsRiField.MSPA_MODE,
+      UsRiField.PROCESSING_NOTICE,
+      UsRiField.SALE_OPT_OUT_NOTICE,
+      UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+      UsRiField.SALE_OPT_OUT,
+      UsRiField.TARGETED_ADVERTISING_OPT_OUT,
+      UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+      UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT
+  });
+  //@formatter:on
+
+  //@formatter:off
+  public static List<String> USRI_SENSITIVE_DATA_CONSENT_SEGMENT_FIELD_NAMES = Arrays.asList(new String[] {
+      UsRiField.SENSITIVE_DATA_PROCESSING
+  });
+  //@formatter:on
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/Sections.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/Sections.java
@@ -35,6 +35,10 @@ public class Sections {
     SECTION_ID_NAME_MAP.put(UsNj.ID, UsNj.NAME);
     SECTION_ID_NAME_MAP.put(UsTn.ID, UsTn.NAME);
     SECTION_ID_NAME_MAP.put(UsMn.ID, UsMn.NAME);
+    SECTION_ID_NAME_MAP.put(UsMd.ID, UsMd.NAME);
+    SECTION_ID_NAME_MAP.put(UsIn.ID, UsIn.NAME);
+    SECTION_ID_NAME_MAP.put(UsKy.ID, UsKy.NAME);
+    SECTION_ID_NAME_MAP.put(UsRi.ID, UsRi.NAME);
 
     SECTION_ORDER = new ArrayList<Integer>(SECTION_ID_NAME_MAP.keySet()).stream().sorted()
         .map(id -> SECTION_ID_NAME_MAP.get(id)).collect(Collectors.toList());

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsIn.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsIn.java
@@ -1,0 +1,132 @@
+package com.iab.gpp.encoder.section;
+
+import com.iab.gpp.encoder.field.UsInField;
+import com.iab.gpp.encoder.segment.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsIn extends AbstractLazilyEncodableSection {
+
+  public static int ID = 25;
+  public static int VERSION = 1;
+  public static String NAME = "usin";
+
+  public UsIn() {
+    super();
+  }
+
+  public UsIn(String encodedString) {
+    super();
+    decode(encodedString);
+  }
+
+  @Override
+  public int getId() {
+    return UsIn.ID;
+  }
+
+  @Override
+  public String getName() {
+    return UsIn.NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return UsIn.VERSION;
+  }
+
+  @Override
+  protected List<EncodableSegment> initializeSegments() {
+    List<EncodableSegment> segments = new ArrayList<>();
+    segments.add(new UsInCoreSegment());
+    segments.add(new UsInSensitiveDataConsentSegment());
+    return segments;
+  }
+
+  @Override
+  protected List<EncodableSegment> decodeSection(String encodedString) {
+    List<EncodableSegment> segments = initializeSegments();
+
+    if (encodedString != null && !encodedString.isEmpty()) {
+      String[] encodedSegments = encodedString.split("\\.");
+
+      if (encodedSegments.length > 0) {
+        segments.get(0).decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments.get(1).setFieldValue(UsInField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, true);
+        segments.get(1).decode(encodedSegments[1]);
+      } else {
+        segments.get(1).setFieldValue(UsInField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  @Override
+  protected String encodeSection(List<EncodableSegment> segments) {
+    List<String> encodedSegments = new ArrayList<>();
+
+    if (!segments.isEmpty()) {
+      encodedSegments.add(segments.get(0).encode());
+      if (segments.size() >= 2 && segments.get(1).getFieldValue(UsInField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED).equals(true)) {
+        encodedSegments.add(segments.get(1).encode());
+      }
+    }
+
+    return String.join(".", encodedSegments);
+  }
+
+
+  public Integer getMspaVersion() {
+    return (Integer) this.getFieldValue(UsInField.MSPA_VERSION);
+  }
+
+  public Integer getMspaCoveredTransaction() {
+    return (Integer) this.getFieldValue(UsInField.MSPA_COVERED_TRANSACTION);
+  }
+
+  public Integer getMspaMode() {
+    return (Integer) this.getFieldValue(UsInField.MSPA_MODE);
+  }
+
+  public Integer getProcessingNotice() {
+    return (Integer) this.getFieldValue(UsInField.PROCESSING_NOTICE);
+  }
+
+  public Integer getSaleOptOutNotice() {
+    return (Integer) this.getFieldValue(UsInField.SALE_OPT_OUT_NOTICE);
+  }
+
+  public Integer getTargetedAdvertisingOptOutNotice() {
+    return (Integer) this.getFieldValue(UsInField.TARGETED_ADVERTISING_OPT_OUT_NOTICE);
+  }
+
+  public Integer getSaleOptOut() {
+    return (Integer) this.getFieldValue(UsInField.SALE_OPT_OUT);
+  }
+
+  public Integer getTargetedAdvertisingOptOut() {
+    return (Integer) this.getFieldValue(UsInField.TARGETED_ADVERTISING_OPT_OUT);
+  }
+
+  public Integer getKnownChildSensitiveDataConsents() {
+    return (Integer) this.getFieldValue(UsInField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS);
+  }
+
+  public Integer getAdditionalDataProcessingConsent() {
+    return (Integer) this.getFieldValue(UsInField.ADDITIONAL_DATA_PROCESSING_CONSENT);
+  }
+
+  public Boolean getSensitiveDataConsentSegmentIncluded() {
+    return (Boolean) this.getFieldValue(UsInField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Integer> getSensitiveDataProcessing() {
+    return (List<Integer>) this.getFieldValue(UsInField.SENSITIVE_DATA_PROCESSING);
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsKy.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsKy.java
@@ -1,0 +1,132 @@
+package com.iab.gpp.encoder.section;
+
+import com.iab.gpp.encoder.field.UsKyField;
+import com.iab.gpp.encoder.segment.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsKy extends AbstractLazilyEncodableSection {
+
+  public static int ID = 26;
+  public static int VERSION = 1;
+  public static String NAME = "usky";
+
+  public UsKy() {
+    super();
+  }
+
+  public UsKy(String encodedString) {
+    super();
+    decode(encodedString);
+  }
+
+  @Override
+  public int getId() {
+    return UsKy.ID;
+  }
+
+  @Override
+  public String getName() {
+    return UsKy.NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return UsKy.VERSION;
+  }
+
+  @Override
+  protected List<EncodableSegment> initializeSegments() {
+    List<EncodableSegment> segments = new ArrayList<>();
+    segments.add(new UsKyCoreSegment());
+    segments.add(new UsKySensitiveDataConsentSegment());
+    return segments;
+  }
+
+  @Override
+  protected List<EncodableSegment> decodeSection(String encodedString) {
+    List<EncodableSegment> segments = initializeSegments();
+
+    if (encodedString != null && !encodedString.isEmpty()) {
+      String[] encodedSegments = encodedString.split("\\.");
+
+      if (encodedSegments.length > 0) {
+        segments.get(0).decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments.get(1).setFieldValue(UsKyField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, true);
+        segments.get(1).decode(encodedSegments[1]);
+      } else {
+        segments.get(1).setFieldValue(UsKyField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  @Override
+  protected String encodeSection(List<EncodableSegment> segments) {
+    List<String> encodedSegments = new ArrayList<>();
+
+    if (!segments.isEmpty()) {
+      encodedSegments.add(segments.get(0).encode());
+      if (segments.size() >= 2 && segments.get(1).getFieldValue(UsKyField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED).equals(true)) {
+        encodedSegments.add(segments.get(1).encode());
+      }
+    }
+
+    return String.join(".", encodedSegments);
+  }
+
+
+  public Integer getMspaVersion() {
+    return (Integer) this.getFieldValue(UsKyField.MSPA_VERSION);
+  }
+
+  public Integer getMspaCoveredTransaction() {
+    return (Integer) this.getFieldValue(UsKyField.MSPA_COVERED_TRANSACTION);
+  }
+
+  public Integer getMspaMode() {
+    return (Integer) this.getFieldValue(UsKyField.MSPA_MODE);
+  }
+
+  public Integer getProcessingNotice() {
+    return (Integer) this.getFieldValue(UsKyField.PROCESSING_NOTICE);
+  }
+
+  public Integer getSaleOptOutNotice() {
+    return (Integer) this.getFieldValue(UsKyField.SALE_OPT_OUT_NOTICE);
+  }
+
+  public Integer getTargetedAdvertisingOptOutNotice() {
+    return (Integer) this.getFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE);
+  }
+
+  public Integer getSaleOptOut() {
+    return (Integer) this.getFieldValue(UsKyField.SALE_OPT_OUT);
+  }
+
+  public Integer getTargetedAdvertisingOptOut() {
+    return (Integer) this.getFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT);
+  }
+
+  public Integer getKnownChildSensitiveDataConsents() {
+    return (Integer) this.getFieldValue(UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS);
+  }
+
+  public Integer getAdditionalDataProcessingConsent() {
+    return (Integer) this.getFieldValue(UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT);
+  }
+
+  public Boolean getSensitiveDataConsentSegmentIncluded() {
+    return (Boolean) this.getFieldValue(UsKyField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Integer> getSensitiveDataProcessing() {
+    return (List<Integer>) this.getFieldValue(UsKyField.SENSITIVE_DATA_PROCESSING);
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsMd.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsMd.java
@@ -1,0 +1,131 @@
+package com.iab.gpp.encoder.section;
+
+import com.iab.gpp.encoder.field.UsMdField;
+import com.iab.gpp.encoder.segment.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsMd extends AbstractLazilyEncodableSection {
+
+  public static int ID = 24;
+  public static int VERSION = 1;
+  public static String NAME = "usmd";
+
+  public UsMd() {
+    super();
+  }
+
+  public UsMd(String encodedString) {
+    super();
+    decode(encodedString);
+  }
+
+  @Override
+  public int getId() {
+    return UsMd.ID;
+  }
+
+  @Override
+  public String getName() {
+    return UsMd.NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return UsMd.VERSION;
+  }
+
+  @Override
+  protected List<EncodableSegment> initializeSegments() {
+    List<EncodableSegment> segments = new ArrayList<>();
+    segments.add(new UsMdCoreSegment());
+    segments.add(new UsMdGpcSegment());
+    return segments;
+  }
+
+  @Override
+  protected List<EncodableSegment> decodeSection(String encodedString) {
+    List<EncodableSegment> segments = initializeSegments();
+
+    if (encodedString != null && !encodedString.isEmpty()) {
+      String[] encodedSegments = encodedString.split("\\.");
+
+      if (encodedSegments.length > 0) {
+        segments.get(0).decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments.get(1).setFieldValue(UsMdField.GPC_SEGMENT_INCLUDED, true);
+        segments.get(1).decode(encodedSegments[1]);
+      } else {
+        segments.get(1).setFieldValue(UsMdField.GPC_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  @Override
+  protected String encodeSection(List<EncodableSegment> segments) {
+    List<String> encodedSegments = new ArrayList<>();
+
+    if (!segments.isEmpty()) {
+      encodedSegments.add(segments.get(0).encode());
+      if (segments.size() >= 2 && segments.get(1).getFieldValue(UsMdField.GPC_SEGMENT_INCLUDED).equals(true)) {
+        encodedSegments.add(segments.get(1).encode());
+      }
+    }
+
+    return String.join(".", encodedSegments);
+  }
+
+
+  public Integer getMspaVersion() {
+    return (Integer) this.getFieldValue(UsMdField.MSPA_VERSION);
+  }
+
+  public Integer getMspaCoveredTransaction() {
+    return (Integer) this.getFieldValue(UsMdField.MSPA_COVERED_TRANSACTION);
+  }
+
+  public Integer getMspaMode() {
+    return (Integer) this.getFieldValue(UsMdField.MSPA_MODE);
+  }
+
+  public Integer getProcessingNotice() {
+    return (Integer) this.getFieldValue(UsMdField.PROCESSING_NOTICE);
+  }
+
+  public Integer getSaleOptOutNotice() {
+    return (Integer) this.getFieldValue(UsMdField.SALE_OPT_OUT_NOTICE);
+  }
+
+  public Integer getTargetedAdvertisingOptOutNotice() {
+    return (Integer) this.getFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE);
+  }
+
+  public Integer getSaleOptOut() {
+    return (Integer) this.getFieldValue(UsMdField.SALE_OPT_OUT);
+  }
+
+  public Integer getTargetedAdvertisingOptOut() {
+    return (Integer) this.getFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT);
+  }
+
+  public Integer getAdditionalDataProcessingConsent() {
+    return (Integer) this.getFieldValue(UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT);
+  }
+
+  public Integer getGpcSegmentType() {
+    return (Integer) this.getFieldValue(UsMdField.GPC_SEGMENT_TYPE);
+  }
+
+  public Boolean getGpcSegmentIncluded() {
+    return (Boolean) this.getFieldValue(UsMdField.GPC_SEGMENT_INCLUDED);
+  }
+
+  public Boolean getGpc() {
+    return (Boolean) this.getFieldValue(UsMdField.GPC);
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsRi.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/section/UsRi.java
@@ -1,0 +1,132 @@
+package com.iab.gpp.encoder.section;
+
+import com.iab.gpp.encoder.field.UsRiField;
+import com.iab.gpp.encoder.segment.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsRi extends AbstractLazilyEncodableSection {
+
+  public static int ID = 27;
+  public static int VERSION = 1;
+  public static String NAME = "usri";
+
+  public UsRi() {
+    super();
+  }
+
+  public UsRi(String encodedString) {
+    super();
+    decode(encodedString);
+  }
+
+  @Override
+  public int getId() {
+    return UsRi.ID;
+  }
+
+  @Override
+  public String getName() {
+    return UsRi.NAME;
+  }
+
+  @Override
+  public int getVersion() {
+    return UsRi.VERSION;
+  }
+
+  @Override
+  protected List<EncodableSegment> initializeSegments() {
+    List<EncodableSegment> segments = new ArrayList<>();
+    segments.add(new UsRiCoreSegment());
+    segments.add(new UsRiSensitiveDataConsentSegment());
+    return segments;
+  }
+
+  @Override
+  protected List<EncodableSegment> decodeSection(String encodedString) {
+    List<EncodableSegment> segments = initializeSegments();
+
+    if (encodedString != null && !encodedString.isEmpty()) {
+      String[] encodedSegments = encodedString.split("\\.");
+
+      if (encodedSegments.length > 0) {
+        segments.get(0).decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments.get(1).setFieldValue(UsRiField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, true);
+        segments.get(1).decode(encodedSegments[1]);
+      } else {
+        segments.get(1).setFieldValue(UsRiField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  @Override
+  protected String encodeSection(List<EncodableSegment> segments) {
+    List<String> encodedSegments = new ArrayList<>();
+
+    if (!segments.isEmpty()) {
+      encodedSegments.add(segments.get(0).encode());
+      if (segments.size() >= 2 && segments.get(1).getFieldValue(UsRiField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED).equals(true)) {
+        encodedSegments.add(segments.get(1).encode());
+      }
+    }
+
+    return String.join(".", encodedSegments);
+  }
+
+
+  public Integer getMspaVersion() {
+    return (Integer) this.getFieldValue(UsRiField.MSPA_VERSION);
+  }
+
+  public Integer getMspaCoveredTransaction() {
+    return (Integer) this.getFieldValue(UsRiField.MSPA_COVERED_TRANSACTION);
+  }
+
+  public Integer getMspaMode() {
+    return (Integer) this.getFieldValue(UsRiField.MSPA_MODE);
+  }
+
+  public Integer getProcessingNotice() {
+    return (Integer) this.getFieldValue(UsRiField.PROCESSING_NOTICE);
+  }
+
+  public Integer getSaleOptOutNotice() {
+    return (Integer) this.getFieldValue(UsRiField.SALE_OPT_OUT_NOTICE);
+  }
+
+  public Integer getTargetedAdvertisingOptOutNotice() {
+    return (Integer) this.getFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE);
+  }
+
+  public Integer getSaleOptOut() {
+    return (Integer) this.getFieldValue(UsRiField.SALE_OPT_OUT);
+  }
+
+  public Integer getTargetedAdvertisingOptOut() {
+    return (Integer) this.getFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT);
+  }
+
+  public Integer getKnownChildSensitiveDataConsents() {
+    return (Integer) this.getFieldValue(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS);
+  }
+
+  public Integer getAdditionalDataProcessingConsent() {
+    return (Integer) this.getFieldValue(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT);
+  }
+
+  public Boolean getSensitiveDataConsentSegmentIncluded() {
+    return (Boolean) this.getFieldValue(UsRiField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Integer> getSensitiveDataProcessing() {
+    return (List<Integer>) this.getFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING);
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsInCoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsInCoreSegment.java
@@ -1,0 +1,82 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsInField;
+import com.iab.gpp.encoder.section.UsIn;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsInCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsInCoreSegment() {
+    super();
+  }
+
+  public UsInCoreSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsInField.USIN_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<Integer> nullableBooleanAsTwoBitIntegerValidator = (n -> n >= 0 && n <= 2);
+    Predicate<Integer> nonNullableBooleanAsTwoBitIntegerValidator = (n -> n >= 1 && n <= 2);
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsInField.MSPA_VERSION, new EncodableFixedInteger(6, UsIn.VERSION));
+    fields.put(UsInField.MSPA_COVERED_TRANSACTION,
+        new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.MSPA_MODE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.PROCESSING_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.SALE_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.SALE_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.TARGETED_ADVERTISING_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsInField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsInCoreSegment '" + encodedString + "'", e);
+    }
+  }
+
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsInSensitiveDataConsentSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsInSensitiveDataConsentSegment.java
@@ -1,0 +1,73 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableBoolean;
+import com.iab.gpp.encoder.datatype.EncodableFixedIntegerList;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsInField;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsInSensitiveDataConsentSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsInSensitiveDataConsentSegment() {
+    super();
+  }
+
+  public UsInSensitiveDataConsentSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsInField.USIN_SENSITIVE_DATA_CONSENT_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<List<Integer>> nullableBooleanAsTwoBitIntegerListValidator = (l -> {
+      for (int n : l) {
+        if (n < 0 || n > 2) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsInField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, new EncodableBoolean(true));
+    fields.put(UsInField.SENSITIVE_DATA_PROCESSING,
+        new EncodableFixedIntegerList(2, Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0))
+            .withValidator(nullableBooleanAsTwoBitIntegerListValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsInSensitiveDataConsentSegment '" + encodedString + "'", e);
+    }
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKyCoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKyCoreSegment.java
@@ -1,0 +1,82 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsKyField;
+import com.iab.gpp.encoder.section.UsKy;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsKyCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsKyCoreSegment() {
+    super();
+  }
+
+  public UsKyCoreSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsKyField.USKY_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<Integer> nullableBooleanAsTwoBitIntegerValidator = (n -> n >= 0 && n <= 2);
+    Predicate<Integer> nonNullableBooleanAsTwoBitIntegerValidator = (n -> n >= 1 && n <= 2);
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsKyField.MSPA_VERSION, new EncodableFixedInteger(6, UsKy.VERSION));
+    fields.put(UsKyField.MSPA_COVERED_TRANSACTION,
+        new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.MSPA_MODE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.PROCESSING_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.SALE_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.SALE_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.TARGETED_ADVERTISING_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsKyCoreSegment '" + encodedString + "'", e);
+    }
+  }
+
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKySensitiveDataConsentSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsKySensitiveDataConsentSegment.java
@@ -1,0 +1,73 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableBoolean;
+import com.iab.gpp.encoder.datatype.EncodableFixedIntegerList;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsKyField;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsKySensitiveDataConsentSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsKySensitiveDataConsentSegment() {
+    super();
+  }
+
+  public UsKySensitiveDataConsentSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsKyField.USKY_SENSITIVE_DATA_CONSENT_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<List<Integer>> nullableBooleanAsTwoBitIntegerListValidator = (l -> {
+      for (int n : l) {
+        if (n < 0 || n > 2) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsKyField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, new EncodableBoolean(true));
+    fields.put(UsKyField.SENSITIVE_DATA_PROCESSING,
+        new EncodableFixedIntegerList(2, Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0))
+            .withValidator(nullableBooleanAsTwoBitIntegerListValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsKySensitiveDataConsentSegment '" + encodedString + "'", e);
+    }
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsMdCoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsMdCoreSegment.java
@@ -1,0 +1,80 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsMdField;
+import com.iab.gpp.encoder.section.UsMd;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsMdCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsMdCoreSegment() {
+    super();
+  }
+
+  public UsMdCoreSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsMdField.USMD_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<Integer> nullableBooleanAsTwoBitIntegerValidator = (n -> n >= 0 && n <= 2);
+    Predicate<Integer> nonNullableBooleanAsTwoBitIntegerValidator = (n -> n >= 1 && n <= 2);
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsMdField.MSPA_VERSION, new EncodableFixedInteger(6, UsMd.VERSION));
+    fields.put(UsMdField.MSPA_COVERED_TRANSACTION,
+        new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.MSPA_MODE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.PROCESSING_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.SALE_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.SALE_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.TARGETED_ADVERTISING_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsMdCoreSegment '" + encodedString + "'", e);
+    }
+  }
+
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsMdGpcSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsMdGpcSegment.java
@@ -1,0 +1,61 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableBoolean;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsMdField;
+
+import java.util.List;
+
+public class UsMdGpcSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsMdGpcSegment() {
+    super();
+  }
+
+  public UsMdGpcSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsMdField.USMD_GPC_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsMdField.GPC_SEGMENT_TYPE, new EncodableFixedInteger(2, 1));
+    fields.put(UsMdField.GPC_SEGMENT_INCLUDED, new EncodableBoolean(true));
+    fields.put(UsMdField.GPC, new EncodableBoolean(false));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if(encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsMdGpcSegment '" + encodedString + "'", e);
+    }
+  }
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiCoreSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiCoreSegment.java
@@ -1,0 +1,82 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableFixedInteger;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsRiField;
+import com.iab.gpp.encoder.section.UsRi;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsRiCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsRiCoreSegment() {
+    super();
+  }
+
+  public UsRiCoreSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsRiField.USRI_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<Integer> nullableBooleanAsTwoBitIntegerValidator = (n -> n >= 0 && n <= 2);
+    Predicate<Integer> nonNullableBooleanAsTwoBitIntegerValidator = (n -> n >= 1 && n <= 2);
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsRiField.MSPA_VERSION, new EncodableFixedInteger(6, UsRi.VERSION));
+    fields.put(UsRiField.MSPA_COVERED_TRANSACTION,
+        new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.MSPA_MODE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.PROCESSING_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.SALE_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.SALE_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.TARGETED_ADVERTISING_OPT_OUT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    fields.put(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+        new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsRiCoreSegment '" + encodedString + "'", e);
+    }
+  }
+
+}

--- a/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiSensitiveDataConsentSegment.java
+++ b/iabgpp-encoder/src/main/java/com/iab/gpp/encoder/segment/UsRiSensitiveDataConsentSegment.java
@@ -1,0 +1,73 @@
+package com.iab.gpp.encoder.segment;
+
+import com.iab.gpp.encoder.base64.AbstractBase64UrlEncoder;
+import com.iab.gpp.encoder.base64.CompressedBase64UrlEncoder;
+import com.iab.gpp.encoder.bitstring.BitStringEncoder;
+import com.iab.gpp.encoder.datatype.EncodableBoolean;
+import com.iab.gpp.encoder.datatype.EncodableFixedIntegerList;
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.field.EncodableBitStringFields;
+import com.iab.gpp.encoder.field.UsRiField;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class UsRiSensitiveDataConsentSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+
+  private AbstractBase64UrlEncoder base64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private BitStringEncoder bitStringEncoder = BitStringEncoder.getInstance();
+
+  public UsRiSensitiveDataConsentSegment() {
+    super();
+  }
+
+  public UsRiSensitiveDataConsentSegment(String encodedString) {
+    super();
+    this.decode(encodedString);
+  }
+
+  @Override
+  public List<String> getFieldNames() {
+    return UsRiField.USRI_SENSITIVE_DATA_CONSENT_SEGMENT_FIELD_NAMES;
+  }
+
+  @Override
+  protected EncodableBitStringFields initializeFields() {
+    Predicate<List<Integer>> nullableBooleanAsTwoBitIntegerListValidator = (l -> {
+      for (int n : l) {
+        if (n < 0 || n > 2) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    EncodableBitStringFields fields = new EncodableBitStringFields();
+    fields.put(UsRiField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, new EncodableBoolean(true));
+    fields.put(UsRiField.SENSITIVE_DATA_PROCESSING,
+        new EncodableFixedIntegerList(2, Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0))
+            .withValidator(nullableBooleanAsTwoBitIntegerListValidator));
+    return fields;
+  }
+
+  @Override
+  protected String encodeSegment(EncodableBitStringFields fields) {
+    String bitString = bitStringEncoder.encode(fields, getFieldNames());
+    String encodedString = base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  @Override
+  protected void decodeSegment(String encodedString, EncodableBitStringFields fields) {
+    if (encodedString == null || encodedString.isEmpty()) {
+      this.fields.reset(fields);
+    }
+    try {
+      String bitString = base64UrlEncoder.decode(encodedString);
+      bitStringEncoder.decode(bitString, getFieldNames(), fields);
+    } catch (Exception e) {
+      throw new DecodingException("Unable to decode UsRiSensitiveDataConsentSegment '" + encodedString + "'", e);
+    }
+  }
+}

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/GppModelTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/GppModelTest.java
@@ -17,6 +17,9 @@ import com.iab.gpp.encoder.section.UsCt;
 import com.iab.gpp.encoder.section.UsDe;
 import com.iab.gpp.encoder.section.UsFl;
 import com.iab.gpp.encoder.section.UsIa;
+import com.iab.gpp.encoder.section.UsIn;
+import com.iab.gpp.encoder.section.UsKy;
+import com.iab.gpp.encoder.section.UsMd;
 import com.iab.gpp.encoder.section.UsMn;
 import com.iab.gpp.encoder.section.UsMt;
 import com.iab.gpp.encoder.section.UsNat;
@@ -24,6 +27,7 @@ import com.iab.gpp.encoder.section.UsNe;
 import com.iab.gpp.encoder.section.UsNh;
 import com.iab.gpp.encoder.section.UsNj;
 import com.iab.gpp.encoder.section.UsOr;
+import com.iab.gpp.encoder.section.UsRi;
 import com.iab.gpp.encoder.section.UsTn;
 import com.iab.gpp.encoder.section.UsTx;
 import com.iab.gpp.encoder.section.UsUt;
@@ -83,6 +87,10 @@ public class GppModelTest {
     Assertions.assertEquals(false, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(false, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(false, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(false, gppModel.hasSection(UsMd.NAME));
+    Assertions.assertEquals(false, gppModel.hasSection(UsIn.NAME));
+    Assertions.assertEquals(false, gppModel.hasSection(UsKy.NAME));
+    Assertions.assertEquals(false, gppModel.hasSection(UsRi.NAME));
 
     gppModel.setFieldValue(TcfEuV2.NAME, TcfEuV2Field.VERSION, TcfEuV2.VERSION);
     gppModel.setFieldValue(TcfEuV2.NAME, TcfCaV1Field.CREATED, utcDateTime);
@@ -108,6 +116,10 @@ public class GppModelTest {
     gppModel.setFieldValue(UsNj.NAME, UsNjField.VERSION, UsNj.VERSION);
     gppModel.setFieldValue(UsTn.NAME, UsTnField.VERSION, UsTn.VERSION);
     gppModel.setFieldValue(UsMn.NAME, UsMnField.VERSION, UsMn.VERSION);
+    gppModel.setFieldValue(UsMd.NAME, UsMdField.MSPA_VERSION, UsMd.VERSION);
+    gppModel.setFieldValue(UsIn.NAME, UsInField.MSPA_VERSION, UsIn.VERSION);
+    gppModel.setFieldValue(UsKy.NAME, UsKyField.MSPA_VERSION, UsKy.VERSION);
+    gppModel.setFieldValue(UsRi.NAME, UsRiField.MSPA_VERSION, UsRi.VERSION);
 
 
     Assertions.assertEquals(true, gppModel.hasSection(TcfEuV2.NAME));
@@ -130,10 +142,14 @@ public class GppModelTest {
     Assertions.assertEquals(true, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsMd.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsIn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsKy.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsRi.NAME));
 
     String gppString = gppModel.encode();
     Assertions.assertEquals(
-            "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA",
+            "DBACOcGA~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAA.QA~BQAA.AAA~BQAA.AAA~BQAA.AAA",
             gppString);
   }
 
@@ -406,7 +422,7 @@ public class GppModelTest {
   @Test
   public void testDecodeDefaultsAll() {
     String gppString =
-        "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAABAA.QA";
+        "DBACOcGA~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAA.QA~BQAA.AAA~BQAA.AAA~BQAA.AAA";
     GppModel gppModel = new GppModel(gppString);
 
     Assertions.assertEquals(true, gppModel.hasSection(TcfEuV2.NAME));
@@ -429,6 +445,10 @@ public class GppModelTest {
     Assertions.assertEquals(true, gppModel.hasSection(UsNj.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsTn.NAME));
     Assertions.assertEquals(true, gppModel.hasSection(UsMn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsMd.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsIn.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsKy.NAME));
+    Assertions.assertEquals(true, gppModel.hasSection(UsRi.NAME));
   }
 
   @Test

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsInTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsInTest.java
@@ -1,0 +1,107 @@
+package com.iab.gpp.encoder.section;
+
+
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.error.ValidationException;
+import com.iab.gpp.encoder.field.UsInField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class UsInTest {
+
+  @Test
+  public void testEncode1() {
+    UsIn usIn = new UsIn();
+    Assertions.assertEquals("BQAA.AAA", usIn.encode());
+  }
+
+  @Test
+  public void testEncode2() {
+    UsIn usIn = new UsIn();
+
+    usIn.setFieldValue(UsInField.MSPA_COVERED_TRANSACTION, 1);
+    usIn.setFieldValue(UsInField.MSPA_MODE, 1);
+    usIn.setFieldValue(UsInField.PROCESSING_NOTICE, 1);
+    usIn.setFieldValue(UsInField.SALE_OPT_OUT_NOTICE, 1);
+    usIn.setFieldValue(UsInField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usIn.setFieldValue(UsInField.SALE_OPT_OUT, 1);
+    usIn.setFieldValue(UsInField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usIn.setFieldValue(UsInField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 1);
+    usIn.setFieldValue(UsInField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usIn.setFieldValue(UsInField.SENSITIVE_DATA_PROCESSING, Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1));
+
+    Assertions.assertEquals("BVVV.kkk", usIn.encode());
+  }
+
+  @Test
+  public void testSetInvalidValues() {
+    UsIn usIn = new UsIn();
+
+    try {
+      usIn.setFieldValue(UsInField.MSPA_COVERED_TRANSACTION, 0);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usIn.setFieldValue(UsInField.MSPA_MODE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usIn.setFieldValue(UsInField.PROCESSING_NOTICE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usIn.setFieldValue(UsInField.SENSITIVE_DATA_PROCESSING, Arrays.asList(0, 1, 2, 3, 1, 2, 0, 1));
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usIn.setFieldValue(UsInField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+  }
+
+  @Test
+  public void testEncodeWithSensitiveDataConsentSegmentExcluded() {
+    UsIn usIn = new UsIn();
+    usIn.setFieldValue(UsInField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, false);
+    Assertions.assertEquals("BQAA", usIn.encode());
+  }
+
+  @Test
+  public void testDecode1() throws DecodingException {
+    UsIn usIn = new UsIn("BVVV.kkk");
+
+    Assertions.assertEquals(1, usIn.getMspaCoveredTransaction());
+    Assertions.assertEquals(1, usIn.getMspaMode());
+    Assertions.assertEquals(1, usIn.getProcessingNotice());
+    Assertions.assertEquals(1, usIn.getSaleOptOutNotice());
+    Assertions.assertEquals(1, usIn.getTargetedAdvertisingOptOutNotice());
+    Assertions.assertEquals(1, usIn.getSaleOptOut());
+    Assertions.assertEquals(1, usIn.getTargetedAdvertisingOptOut());
+    Assertions.assertEquals(1, usIn.getKnownChildSensitiveDataConsents());
+    Assertions.assertEquals(1, usIn.getAdditionalDataProcessingConsent());
+    Assertions.assertEquals(Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1), usIn.getSensitiveDataProcessing());
+  }
+
+  @Test()
+  public void testDecodeGarbage() {
+    Assertions.assertThrows(DecodingException.class, () -> {
+      new UsIn("z").getProcessingNotice();
+    });
+  }
+}

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsKyTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsKyTest.java
@@ -1,0 +1,93 @@
+package com.iab.gpp.encoder.section;
+
+
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.error.ValidationException;
+import com.iab.gpp.encoder.field.UsKyField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class UsKyTest {
+
+  @Test
+  public void testEncode1() {
+    UsKy usKy = new UsKy();
+    Assertions.assertEquals("BQAA.AAA", usKy.encode());
+  }
+
+  @Test
+  public void testEncode2() {
+    UsKy usKy = new UsKy();
+
+    usKy.setFieldValue(UsKyField.MSPA_COVERED_TRANSACTION, 1);
+    usKy.setFieldValue(UsKyField.MSPA_MODE, 1);
+    usKy.setFieldValue(UsKyField.PROCESSING_NOTICE, 1);
+    usKy.setFieldValue(UsKyField.SALE_OPT_OUT_NOTICE, 1);
+    usKy.setFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usKy.setFieldValue(UsKyField.SALE_OPT_OUT, 1);
+    usKy.setFieldValue(UsKyField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usKy.setFieldValue(UsKyField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 1);
+    usKy.setFieldValue(UsKyField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usKy.setFieldValue(UsKyField.SENSITIVE_DATA_PROCESSING, Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1));
+
+    Assertions.assertEquals("BVVV.kkk", usKy.encode());
+  }
+
+  @Test
+  public void testSetInvalidValues() {
+    UsKy usKy = new UsKy();
+
+    try {
+      usKy.setFieldValue(UsKyField.MSPA_COVERED_TRANSACTION, 0);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usKy.setFieldValue(UsKyField.MSPA_MODE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usKy.setFieldValue(UsKyField.SENSITIVE_DATA_PROCESSING, Arrays.asList(0, 1, 2, 3, 1, 2, 0, 1));
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+  }
+
+  @Test
+  public void testEncodeWithSensitiveDataConsentSegmentExcluded() {
+    UsKy usKy = new UsKy();
+    usKy.setFieldValue(UsKyField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, false);
+    Assertions.assertEquals("BQAA", usKy.encode());
+  }
+
+  @Test
+  public void testDecode1() throws DecodingException {
+    UsKy usKy = new UsKy("BVVV.kkk");
+
+    Assertions.assertEquals(1, usKy.getMspaCoveredTransaction());
+    Assertions.assertEquals(1, usKy.getMspaMode());
+    Assertions.assertEquals(1, usKy.getProcessingNotice());
+    Assertions.assertEquals(1, usKy.getSaleOptOutNotice());
+    Assertions.assertEquals(1, usKy.getTargetedAdvertisingOptOutNotice());
+    Assertions.assertEquals(1, usKy.getSaleOptOut());
+    Assertions.assertEquals(1, usKy.getTargetedAdvertisingOptOut());
+    Assertions.assertEquals(1, usKy.getKnownChildSensitiveDataConsents());
+    Assertions.assertEquals(1, usKy.getAdditionalDataProcessingConsent());
+    Assertions.assertEquals(Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1), usKy.getSensitiveDataProcessing());
+  }
+
+  @Test()
+  public void testDecodeGarbage() {
+    Assertions.assertThrows(DecodingException.class, () -> {
+      new UsKy("z").getProcessingNotice();
+    });
+  }
+}

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsMdTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsMdTest.java
@@ -1,0 +1,124 @@
+package com.iab.gpp.encoder.section;
+
+
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.error.ValidationException;
+import com.iab.gpp.encoder.field.UsMdField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class UsMdTest {
+
+  @Test
+  public void testEncode1() {
+    UsMd usMd = new UsMd();
+    Assertions.assertEquals("BQAA.QA", usMd.encode());
+  }
+
+  @Test
+  public void testEncode2() {
+    UsMd usMd = new UsMd();
+
+    usMd.setFieldValue(UsMdField.MSPA_COVERED_TRANSACTION, 1);
+    usMd.setFieldValue(UsMdField.MSPA_MODE, 1);
+    usMd.setFieldValue(UsMdField.PROCESSING_NOTICE, 1);
+    usMd.setFieldValue(UsMdField.SALE_OPT_OUT_NOTICE, 1);
+    usMd.setFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usMd.setFieldValue(UsMdField.SALE_OPT_OUT, 1);
+    usMd.setFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usMd.setFieldValue(UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usMd.setFieldValue(UsMdField.GPC, true);
+
+    Assertions.assertEquals("BVVU.YA", usMd.encode());
+  }
+
+  @Test
+  public void testSetInvalidValues() {
+    UsMd usMd = new UsMd();
+
+    try {
+      usMd.setFieldValue(UsMdField.MSPA_COVERED_TRANSACTION, 0);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.MSPA_MODE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.PROCESSING_NOTICE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.SALE_OPT_OUT_NOTICE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.SALE_OPT_OUT, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT, -1);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usMd.setFieldValue(UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+  }
+
+  @Test
+  public void testEncodeWithGpcSegmentExcluded() {
+    UsMd usMd = new UsMd();
+    usMd.setFieldValue(UsMdField.GPC_SEGMENT_INCLUDED, false);
+    Assertions.assertEquals("BQAA", usMd.encode());
+  }
+
+  @Test
+  public void testDecode1() throws DecodingException {
+    UsMd usMd = new UsMd("BVVU.YA");
+
+    Assertions.assertEquals(1, usMd.getMspaCoveredTransaction());
+    Assertions.assertEquals(1, usMd.getMspaMode());
+    Assertions.assertEquals(1, usMd.getProcessingNotice());
+    Assertions.assertEquals(1, usMd.getSaleOptOutNotice());
+    Assertions.assertEquals(1, usMd.getTargetedAdvertisingOptOutNotice());
+    Assertions.assertEquals(1, usMd.getSaleOptOut());
+    Assertions.assertEquals(1, usMd.getTargetedAdvertisingOptOut());
+    Assertions.assertEquals(1, usMd.getAdditionalDataProcessingConsent());
+    Assertions.assertEquals(true, usMd.getGpc());
+  }
+
+  @Test()
+  public void testDecodeGarbage() {
+    Assertions.assertThrows(DecodingException.class, () -> {
+      new UsMd("z").getProcessingNotice();
+    });
+  }
+}

--- a/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsRiTest.java
+++ b/iabgpp-encoder/src/test/java/com/iab/gpp/encoder/section/UsRiTest.java
@@ -1,0 +1,93 @@
+package com.iab.gpp.encoder.section;
+
+
+import com.iab.gpp.encoder.error.DecodingException;
+import com.iab.gpp.encoder.error.ValidationException;
+import com.iab.gpp.encoder.field.UsRiField;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class UsRiTest {
+
+  @Test
+  public void testEncode1() {
+    UsRi usRi = new UsRi();
+    Assertions.assertEquals("BQAA.AAA", usRi.encode());
+  }
+
+  @Test
+  public void testEncode2() {
+    UsRi usRi = new UsRi();
+
+    usRi.setFieldValue(UsRiField.MSPA_COVERED_TRANSACTION, 1);
+    usRi.setFieldValue(UsRiField.MSPA_MODE, 1);
+    usRi.setFieldValue(UsRiField.PROCESSING_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.SALE_OPT_OUT_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.SALE_OPT_OUT, 1);
+    usRi.setFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usRi.setFieldValue(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 1);
+    usRi.setFieldValue(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usRi.setFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING, Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1));
+
+    Assertions.assertEquals("BVVV.kkk", usRi.encode());
+  }
+
+  @Test
+  public void testSetInvalidValues() {
+    UsRi usRi = new UsRi();
+
+    try {
+      usRi.setFieldValue(UsRiField.MSPA_COVERED_TRANSACTION, 0);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usRi.setFieldValue(UsRiField.MSPA_MODE, 3);
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+
+    try {
+      usRi.setFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING, Arrays.asList(0, 1, 2, 3, 1, 2, 0, 1));
+      Assertions.fail("Expected ValidationException");
+    } catch (ValidationException e) {
+
+    }
+  }
+
+  @Test
+  public void testEncodeWithSensitiveDataConsentSegmentExcluded() {
+    UsRi usRi = new UsRi();
+    usRi.setFieldValue(UsRiField.SENSITIVE_DATA_CONSENT_SEGMENT_INCLUDED, false);
+    Assertions.assertEquals("BQAA", usRi.encode());
+  }
+
+  @Test
+  public void testDecode1() throws DecodingException {
+    UsRi usRi = new UsRi("BVVV.kkk");
+
+    Assertions.assertEquals(1, usRi.getMspaCoveredTransaction());
+    Assertions.assertEquals(1, usRi.getMspaMode());
+    Assertions.assertEquals(1, usRi.getProcessingNotice());
+    Assertions.assertEquals(1, usRi.getSaleOptOutNotice());
+    Assertions.assertEquals(1, usRi.getTargetedAdvertisingOptOutNotice());
+    Assertions.assertEquals(1, usRi.getSaleOptOut());
+    Assertions.assertEquals(1, usRi.getTargetedAdvertisingOptOut());
+    Assertions.assertEquals(1, usRi.getKnownChildSensitiveDataConsents());
+    Assertions.assertEquals(1, usRi.getAdditionalDataProcessingConsent());
+    Assertions.assertEquals(Arrays.asList(2, 1, 0, 2, 1, 0, 2, 1), usRi.getSensitiveDataProcessing());
+  }
+
+  @Test()
+  public void testDecodeGarbage() {
+    Assertions.assertThrows(DecodingException.class, () -> {
+      new UsRi("z").getProcessingNotice();
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements four new MSPA state sections per the latest GPP MSPA spec:

- **US-MD** Maryland (Section ID 24)
- **US-IN** Indiana (Section ID 25)
- **US-KY** Kentucky (Section ID 26)
- **US-RI** Rhode Island (Section ID 27)

Each section follows the same pattern as the existing US-MN section: a Core + GPC segment pair, registered in \`Sections.java\` and dispatched from \`GppModel\` for encode/decode, with per-state fields, segments, and a section class.

## Test plan

- [x] \`mvn test\` passes (388 tests)
- [x] \`GppModelTest.testEncodeDefaultAll\` exercises all four new sections in the consolidated GPP string
- [x] Per-section round-trip tests added under \`com.iab.gpp.encoder.section\`